### PR TITLE
Fix syntax for .show databases

### DIFF
--- a/data-explorer/kusto/management/show-databases.md
+++ b/data-explorer/kusto/management/show-databases.md
@@ -17,7 +17,7 @@ To see return a table showing the properties of the context database, see [.show
 
 **Syntax**
 
-`.show` `database`
+`.show` `databases`
 
 **Output schema**
 


### PR DESCRIPTION
It currently shows `.show database` as syntax for `.show databases`.