### PR TITLE
Adding two Key Vault & identity endpoints for enabling Encryption option

### DIFF
--- a/data-explorer/vnet-deployment.md
+++ b/data-explorer/vnet-deployment.md
@@ -229,6 +229,8 @@ azureprofilerfrontdoor.cloudapp.net:443
 *.servicebus.windows.net:443
 shoebox2.metrics.nsatc.net:443
 prod-dsts.dsts.core.windows.net:443
+*.identity.azure.net:443
+*.vault.azure.net:443
 ocsp.msocsp.com:80
 *.windowsupdate.com:80
 ocsp.digicert.com:80


### PR DESCRIPTION
After investigating AT & T issue, we found that two Key Vault & identity endpoints  would need to whitelist in the customer firewall for enabling encryption option with customer's key vault