### PR TITLE
Corrects on-premises in vnet-create-cluster-portal

### DIFF
--- a/data-explorer/vnet-create-cluster-portal.md
+++ b/data-explorer/vnet-create-cluster-portal.md
@@ -13,7 +13,7 @@ ms.date: 03/24/2020
 
 # Create an Azure Data Explorer cluster in your virtual network
 
-Azure Data Explorer supports deploying a cluster into a subnet in your virtual network (VNet). This capability enables you to access the cluster privately from your Azure virtual network or on-premise, access resource such as Event Hub and Storage inside your virtual network, and restrict inbound and outbound traffic.
+Azure Data Explorer supports deploying a cluster into a subnet in your virtual network (VNet). This capability enables you to access the cluster privately from your Azure virtual network or on-premises, access resource such as Event Hub and Storage inside your virtual network, and restrict inbound and outbound traffic.
 
 ## Prerequisites
 


### PR DESCRIPTION
It is common to use on-premise while the correct way is on-premises

Please see: 
https://www.webopedia.com/TERM/O/on-premises.html
https://en.wikipedia.org/wiki/On-premises_software