### PR TITLE
Update links to Kusto Data Explorer to plain URLs

### DIFF
--- a/data-explorer/kusto/tools/kusto-webexplorer.md
+++ b/data-explorer/kusto/tools/kusto-webexplorer.md
@@ -13,7 +13,7 @@ ms.date: 02/24/2020
 
 Kusto.WebExplorer is a web application that can be used to send queries
 and control commands to a Kusto service. The application is hosted at
-[https://dataexplorer.azure.com/] and short-linked by [https://aka.ms/kwe].
+https://dataexplorer.azure.com/ and short-linked by https://aka.ms/kwe.
 
 
 


### PR DESCRIPTION
Just fixing the links so they display better on the docs site: https://docs.microsoft.com/en-us/azure/data-explorer/kusto/tools/kusto-webexplorer