### PR TITLE
Update python-query-data.md

### DIFF
--- a/data-explorer/python-query-data.md
+++ b/data-explorer/python-query-data.md
@@ -38,7 +38,7 @@ pip install azure-kusto-data
 Import classes from the library, as well as *pandas*, a data analysis library.
 
 ```python
-from azure.kusto.data.request import KustoClient, KustoConnectionStringBuilder
+from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 from azure.kusto.data.exceptions import KustoServiceError
 from azure.kusto.data.helpers import dataframe_from_result_table
 import pandas as pd


### PR DESCRIPTION
There's no `request` module anymore.

```
>>> from azure.kusto.data import request
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'request' from 'azure.kusto.data' (C:\Users\davxi\.virtualenvs\DataExplorerExercise-jyrV0Qbu\lib\site-packages\azure\kusto\data\__init__.py)
>>> from azure.kusto.data import KustoClient
>>>
```