### PR TITLE
parsertype parameter is case sensitive

### DIFF
--- a/data-explorer/kusto/query/parse-command-line.md
+++ b/data-explorer/kusto/query/parse-command-line.md
@@ -20,7 +20,7 @@ Parses a Unicode command-line string and returns a dynamic array of the command-
 ## Arguments
 
 * *command_line*: Command line to parse.
-* *parser_type*: The only value that is currently supported is `"Windows"`, which parses the command line the same way as [CommandLineToArgvW](/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw).
+* *parser_type*: The only value that is currently supported is `"windows"`, which parses the command line the same way as [CommandLineToArgvW](/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw).
 
 ## Returns
 


### PR DESCRIPTION
The parser-type parameter is case sensitive. The example is correct, but within the text, windows was written with a upper case W, which is wrong, it wont work.