### PR TITLE
Update web-query-data.md

### DIFF
--- a/data-explorer/web-query-data.md
+++ b/data-explorer/web-query-data.md
@@ -86,7 +86,8 @@ You can now run queries on both clusters (assuming you have data in your test cl
 1. Copy and paste the following query into the query window, below the first query. Notice how it isn't formatted on separate lines like the first query.
 
     ```kusto
-    StormEvents | sort by StartTime desc | project StartTime, EndTime, State, EventType, DamageProperty, EpisodeNarrative | take 10
+    StormEvents | sort by StartTime desc 
+    | project StartTime, EndTime, State, EventType, DamageProperty, EpisodeNarrative | take 10
     ```
 
 1. Select the new query. Press *Shift+Alt+F* to format the query, so it looks like the following query.


### PR DESCRIPTION
Formatting doesn't break a one line query into multiple lines. A query will be broken into multiple lines if at least one pipe is in a separate line.

For example: 
Formatting does nothing to `StormEvents | take 10 | project StartTime` 
However, formatting formats this 2 lines query: 
```
StormEvents | take 10 
| project StartTime
``` 
Into this 3 lines query:
```
StormEvents 
| take 10 
| project StartTime
```