### PR TITLE
Update rowlevelsecuritypolicy.md

### DIFF
--- a/data-explorer/kusto/management/rowlevelsecuritypolicy.md
+++ b/data-explorer/kusto/management/rowlevelsecuritypolicy.md
@@ -39,6 +39,10 @@ The RLS policy can't be enabled on a table:
 * for which [continuous data export](../management/data-export/continuous-data-export.md) is configured.
 * referenced by a query of an [update policy](./updatepolicy.md).
 * on which [restricted view access policy](./restrictedviewaccesspolicy.md) is configured.
+* You can only have one RLS policy configured to a table
+
+> [!NOTE]
+> When you enable RLS policy, principals that are not included in the RLS won't see data in the table, including Admins.
 
 ## Examples
 


### PR DESCRIPTION
Hey,

Working with the RLS, I learn two things "the hard way" and I think its important for other to know:
1. you can only have 1 RLS policy enabled on a table
2. you must include "read all" for admins if you want them to be able to query the data after enabling RLS

Thanks!