### PR TITLE
Correct confusing column name fill_forward

### DIFF
--- a/data-explorer/kusto/query/series-fill-backwardfunction.md
+++ b/data-explorer/kusto/query/series-fill-backwardfunction.md
@@ -47,7 +47,7 @@ let data = datatable(arr: dynamic)
 ];
 data 
 | project arr, 
-          fill_forward = series_fill_backward(arr)
+          fill_backward = series_fill_backward(arr)
 
 ```
 


### PR DESCRIPTION
In the example KQL for the series_fill_backward() function the variable projected is "fill_forward", which is confusing. (I expect its been copy/pasted from the fill forward example and not changed fully:   fill_forward = series_fill_backward(arr)