### PR TITLE
 Add json example to clarify the usage of options

### DIFF
--- a/data-explorer/kusto/api/netfx/request-properties.md
+++ b/data-explorer/kusto/api/netfx/request-properties.md
@@ -113,6 +113,11 @@ The following example shows sample client code for using request properties:
             "maxmemoryconsumptionperiterator": 68719476736,
             "max_memory_consumption_per_query_per_node": 68719476736,
             "servertimeout": "50m"
+        },
+        "Parameters": {
+            "xIntValue": 111,
+            "xStrValue": "abc",
+            "xDoubleValue": 11.1
         }
     }
 }

--- a/data-explorer/kusto/api/netfx/request-properties.md
+++ b/data-explorer/kusto/api/netfx/request-properties.md
@@ -103,6 +103,22 @@ In the REST API, query parameters appear in the same JSON-encoded string as the 
 
 The following example shows sample client code for using request properties:
 
+#### Json body
+```json
+{
+    "db": "databaseName",
+    "csl": "QueryHistory | where Duration > 4m and ClientActivityId contains 'unspecified'",
+    "properties": {
+        "Options": {
+            "maxmemoryconsumptionperiterator": 68719476736,
+            "max_memory_consumption_per_query_per_node": 68719476736,
+            "servertimeout": "50m"
+        }
+    }
+}
+```
+
+#### Csharp client
 ```csharp
 public static System.Data.IDataReader QueryKusto(
     Kusto.Data.Common.ICslQueryProvider queryProvider,


### PR DESCRIPTION
Upon using the rest api endpoint for Kusto queries I was confused on how to use properties because my instinct was that to set options I will only have to do 
```
{
    "db": "databaseName",
    "csl": "QueryHistory | where Duration > 4m and ClientActivityId contains 'unspecified'",
    "properties": {
        "maxmemoryconsumptionperiterator": 68719476736,
        "max_memory_consumption_per_query_per_node": 68719476736,
        "servertimeout": "50m"
    }
}
```
but instead it should be 
```
{
    "db": "databaseName",
    "csl": "QueryHistory | where Duration > 4m and ClientActivityId contains 'unspecified'",
    "properties": {
        "Options": {
            "maxmemoryconsumptionperiterator": 68719476736,
            "max_memory_consumption_per_query_per_node": 68719476736,
            "servertimeout": "50m"
        }
    }
}
```

Hence the example addition to the doc to help further clarify the api usage when sending POST requests.