### PR TITLE
Fixed column name in example for series_fill_backward Kusto function

### DIFF
--- a/data-explorer/kusto/query/series-fill-backwardfunction.md
+++ b/data-explorer/kusto/query/series-fill-backwardfunction.md
@@ -51,9 +51,9 @@ data
 
 ```
 
-|`arr`|`fill_forward`|
+|`arr`|`fill_backward`|
 |---|---|
-|[111,null,36,41,null,null,16,61,33,null,null]|[111,36,36,41,16, 16,16,61,33,null,null]|
+|[111,null,36,41,null,null,16,61,33,null,null]|[111,36,36,41,16,16,16,61,33,null,null]|
 
   
 Use [series_fill_forward](series-fill-forwardfunction.md) or [series-fill-const](series-fill-constfunction.md) to complete interpolation of the above array.


### PR DESCRIPTION
Just noticed that the second column name in the results for the example query for the series_fill_backward Kusto function is called `fill_forward` when it should be `fill_backward` to match the name given in the body of the query. Additionally, there is an extra space in the array with the value for that column. This PR corrects both of those issues.