### PR TITLE
remove newline in Kusto sample query

### DIFF
--- a/data-explorer/kusto/query/samples.md
+++ b/data-explorer/kusto/query/samples.md
@@ -57,7 +57,6 @@ Example:
 
 ```kusto
 let Events = MyLogTable | where ... ;
-
 Events
 | where Name == "Start"
 | project Name, City, SessionId, StartTime=timestamp


### PR DESCRIPTION
The newline between a `let` assignment was breaking the sample into two queries instead of one, which prevented the example code from executing as a single query in the Azure Date Explorer interface, resulting in the error `The name 'Events' does not refer to any known column, table, variable or function.`