### PR TITLE
Fix stdevp link

### DIFF
--- a/data-explorer/kusto/query/stdev-aggfunction.md
+++ b/data-explorer/kusto/query/stdev-aggfunction.md
@@ -13,7 +13,7 @@ ms.date: 02/13/2020
 
 Calculates the standard deviation of *Expr* across the group, using [Bessel's correction](https://en.wikipedia.org/wiki/Bessel's_correction) for a small data set that is considered a [sample](https://en.wikipedia.org/wiki/Sample_%28statistics%29). 
 
-For a large data set that is representative of the population, use [stdev() (aggregation function)](stdev-aggfunction.md).
+For a large data set that is representative of the population, use [stdevp() (aggregation function)](stdevp-aggfunction.md).
 
 * Used formula:
 


### PR DESCRIPTION
Currently this page links to itself, it should link to the docs for stdevp().