### PR TITLE
Add double backslash for meta-character uses in regex docs

### DIFF
--- a/data-explorer/kusto/query/re2-library.md
+++ b/data-explorer/kusto/query/re2-library.md
@@ -15,7 +15,7 @@ For information on the use of regular expressions in Azure Data Explorer, see [R
 
 Regular expressions are a notation for describing sets of character strings. When a particular string is in the set described by a regular expression, we often say that the regular expression matches the string.
 
-The simplest regular expression is a single literal character. Except for the metacharacters like *+?()|, characters match themselves. To match a metacharacter, escape it with a backslash: \\+ matches a literal plus character.
+The simplest regular expression is a single literal character. Except for the metacharacters like *+?()|, characters match themselves. To match a metacharacter, escape it with a backslash: \\\\+ matches a literal plus character.
 
 Two regular expressions can be alternated or concatenated to form a new regular expression: if e1 matches s and e2 matches t, then e1|e2 matches s or t, and e1e2 matches st.
 


### PR DESCRIPTION
In the regex docs (https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/re2-library) it says to use only a single backslash to match a meta-character. (see the below image)
![image](https://user-images.githubusercontent.com/17524063/132476036-12ce59c4-714e-47f8-b50e-c63d1ae6bcbb.png)
 
But this should be changed to double backslash (`\\+`).
The correct pattern is added in source, but markdown identifies it in the wrong way. So adding four backslashes(`\\\\`) in the source to make it appear correctly in the docs.