### PR TITLE
Add TOC entry for iff()

### DIFF
--- a/data-explorer/kusto/query/toc.yml
+++ b/data-explorer/kusto/query/toc.yml
@@ -507,6 +507,8 @@ items:
     href: hllmergefunction.md
   - name: hourofday()
     href: hourofdayfunction.md
+  - name: iff()
+    href: ifffunction.md
   - name: iif()
     href: iiffunction.md
   - name: indexof()


### PR DESCRIPTION
The page [already exists](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/ifffunction) and is linked to from `iif()`:

https://github.com/MicrosoftDocs/dataexplorer-docs/blob/b9ef74aeca35c78e37335beb98907643301934b5/data-explorer/kusto/query/iiffunction.md#L40