### PR TITLE
Fix syntax for .show materialized view RLS policy

### DIFF
--- a/data-explorer/kusto/management/show-materialized-view-row-level-security-policy-command.md
+++ b/data-explorer/kusto/management/show-materialized-view-row-level-security-policy-command.md
@@ -17,7 +17,7 @@ For more information about running queries on the row level security policy, see
 
 ## Syntax
 
-`.display` `materialized-view` *MaterializedViewName* `policy` `row_level_security`
+`.show` `materialized-view` *MaterializedViewName* `policy` `row_level_security`
 
 ## Arguments
 

--- a/data-explorer/kusto/management/show-materialized-view-row-level-security-policy-command.md
+++ b/data-explorer/kusto/management/show-materialized-view-row-level-security-policy-command.md
@@ -32,5 +32,5 @@ Returns a JSON representation of the policy.
 Display the policy at the materialized-view level:
 
 ```kusto
-.show materialized-view MyMaterializeView policy row_level_security
+.show materialized-view MyMaterializedView policy row_level_security
 ```

--- a/data-explorer/kusto/management/show-materialized-view-row-level-security-policy-command.md
+++ b/data-explorer/kusto/management/show-materialized-view-row-level-security-policy-command.md
@@ -17,7 +17,7 @@ For more information about running queries on the row level security policy, see
 
 ## Syntax
 
-`.display` `materialized-view` *MaterializedViewName* `policy` `row-level-security` [`enable` | `disable`]
+`.display` `materialized-view` *MaterializedViewName* `policy` `row_level_security`
 
 ## Arguments
 
@@ -32,5 +32,5 @@ Returns a JSON representation of the policy.
 Display the policy at the materialized-view level:
 
 ```kusto
-.show materialized-view MyMaterializeView policy row-level-security
+.show materialized-view MyMaterializeView policy row_level_security
 ```


### PR DESCRIPTION
It says ".display" instead of ".show" and has an erroneous enable/disable argument at the end (that can only be used with .alter). Also, "row-level-security" needs to have underscores, not hyphens.