### PR TITLE
Removed comma from ARM sample template json

### DIFF
--- a/data-explorer/create-cluster-database-resource-manager.md
+++ b/data-explorer/create-cluster-database-resource-manager.md
@@ -93,7 +93,7 @@ In this article, you use an [existing quickstart template](https://azure.microso
               },
               "enablePurge": false,
               "enableDoubleEncryption": false,
-              "engineType": "V3",
+              "engineType": "V3"
           }
       },
       {


### PR DESCRIPTION
In the ADX create cluster & database docs ([https://docs.microsoft.com/en-us/azure/data-explorer/create-cluster-database-resource-manager](url)) it has invalid sample ARM template json because of "**,**" (comma). (see the image below)
![invalid_arm_template](https://user-images.githubusercontent.com/24843888/146577783-d109b9d3-d55f-4e26-956d-35fa9d053ed1.png)

Removed comma to make it syntactically correct.
