### PR TITLE
Update output for the query example

### DIFF
--- a/data-explorer/kusto/query/index.md
+++ b/data-explorer/kusto/query/index.md
@@ -47,7 +47,7 @@ StormEvents
 > [!NOTE]
 > KQL is case-sensitive for everything – table names, table column names, operators, functions, and so on.
 
-This query has a single tabular expression statement. The statement begins with a reference to a table called *StormEvents* and contains several operators, [`where`](whereoperator.md) and [`count`](countoperator.md), each separated by a pipe. The data rows for the source table are filtered by the value of the *StartTime* column and then filtered by the value of the *State* column. In the last line, the query returns a table with a single column and a single row containing the count of the filtered rows.
+This query has a single tabular expression statement. The statement begins with a reference to a table called *StormEvents* and contains several operators, [`where`](whereoperator.md) and [`count`](countoperator.md), each separated by a pipe. The data rows for the source table are filtered by the value of the *StartTime* column and then filtered by the value of the *State* column. In the last line, the query returns a table with a single column and a single row containing the count of the remaining rows.
 
 [Run this query](https://dataexplorer.azure.com/clusters/help/databases/Samples?query=H4sIAAAAAAAAAwsuyS/KdS1LzSspVuCqUSjPSC1KVQguSSwqCcnMTVVISi0pT03NU9BISSxJLQGKaBgZGJjrGhrqGhhqKujpKaCJG4HENZENKklVsLVVUHLz8Q/ydHFUUgDZkpxfmlcCAIItD6l6AAAA)
 to see the result:

--- a/data-explorer/kusto/query/index.md
+++ b/data-explorer/kusto/query/index.md
@@ -47,14 +47,14 @@ StormEvents
 > [!NOTE]
 > KQL is case-sensitive for everything – table names, table column names, operators, functions, and so on.
 
-This query has a single tabular expression statement. The statement begins with a reference to a table called *StormEvents* and contains several operators, [`where`](whereoperator.md) and [`count`](countoperator.md), each separated by a pipe. The data rows for the source table are filtered by the value of the *StartTime* column and then filtered by the value of the *State* column. In the last line, the query returns a table with a single column and a single row containing the count of the remaining rows.
+This query has a single tabular expression statement. The statement begins with a reference to a table called *StormEvents* and contains several operators, [`where`](whereoperator.md) and [`count`](countoperator.md), each separated by a pipe. The data rows for the source table are filtered by the value of the *StartTime* column and then filtered by the value of the *State* column. In the last line, the query returns a table with a single column and a single row containing the count of the filtered rows.
 
 [Run this query](https://dataexplorer.azure.com/clusters/help/databases/Samples?query=H4sIAAAAAAAAAwsuyS/KdS1LzSspVuCqUSjPSC1KVQguSSwqCcnMTVVISi0pT03NU9BISSxJLQGKaBgZGJjrGhrqGhhqKujpKaCJG4HENZENKklVsLVVUHLz8Q/ydHFUUgDZkpxfmlcCAIItD6l6AAAA)
 to see the result:
 
 |Count|
 |-----|
-|   23|
+|   28|
 
 To try out some more Kusto queries, see [Tutorial: Use Kusto queries](tutorial.md).
 


### PR DESCRIPTION
The example query returns a table with a single column and a single row containing the count of the filtered rows. The filters applied in the query are for a specific time range and  for a specific state. The refined output contains records only for the specified time range and the specified state.
The count value is 28.