### PR TITLE
Correction about the "randomness" of take-any-aggfunction.md

### DIFF
--- a/data-explorer/kusto/query/take-any-aggfunction.md
+++ b/data-explorer/kusto/query/take-any-aggfunction.md
@@ -38,6 +38,9 @@ per value of the compound group key.
 When the function is provided with a single column reference, it will attempt to
 return a non-null/non-empty value, if such value is present.
 
+> [!NOTE]
+> `take_any()` function does not select a value according to a pseudo-random function. Multiple results of the function can't be expected to follow a random pattern.
+
 As a result of the random nature of this function, using it multiple times in
 a single application of the `summarize` operator is not equivalent to using
 it a single time with multiple expressions. The former may have each application


### PR DESCRIPTION
I think people should not expect take_any() function to be "random".

Please, could you check the following with a developer?

I manage a Sentinel Workspace, one of the tables we ingest is DeviceNetworkEvents (from Defender for Endpoint). What I will show below does not happen for each of my tables, but I believe this consideration I propose about take_any() is independent from the table (this is something a developer should check). The wording of the change could be improved.

**Reason for this proposal**

I execute an example query like this one:

```
DeviceNetworkEvents
| where Timestamp > ago(3d)
| extend Difference = datetime_diff('second', ingestion_time(), Timestamp)
| summarize
    take_any(ingestion_time(), Timestamp),
    PercentileDifference = percentile(Difference, 50),
    AverageDifference = avg(Difference)
    by Type, SecondTime = bin(Timestamp, 3m)
| extend TakeAnyDifference = datetime_diff('second', $IngestionTime, Timestamp)
| project SecondTime, TakeAnyDifference, PercentileDifference, AverageDifference
| render scatterchart
```

And I get:

![image](https://user-images.githubusercontent.com/2527990/168379184-9a2fee24-965c-406d-bbd0-057fc7dc4024.png)

I get the same results when querying this table in "Microsoft 365 Defender > Advanced Hunting".

If take_any() was pseudo-random, the values of TakeAnyDifference would try to follow an **horizontal** line. This line could be close or separated from PercentileDifference and AverageDifference values, but it should be horizontal. If take_any() was pseudo-random, TakeAnyDifference values should not be scattered around these distinct diagonal lines. I think this diagonal pattern could be explained through the ingestion characteristics of these events and take_any not being pseudo-random.