### PR TITLE
Add an example of AddTrustedHosts to the kusto.md

### DIFF
--- a/data-explorer/kusto/api/connection-strings/kusto.md
+++ b/data-explorer/kusto/api/connection-strings/kusto.md
@@ -60,10 +60,11 @@ the default policy, or `AddTrustedHosts` which adds new entries to the existing 
 ```csharp
 Kusto.Data.Common.Impl.WellKnownKustoEndpoints.AddTrustedHosts(
     new[] {
-        new FastSuffixMatcher.MatchRule("trusted.host", exact: true)
+        // Allow an explicit service address
+        new FastSuffixMatcher.MatchRule("my-kusto.contoso.com", exact: true),
+        // Allow services whose DNS name end with ".contoso.com"
+        new FastSuffixMatcher.MatchRule(".contoso.com", exact: false),
     });
-```
-
 ## Connection string properties
 
 The following table lists all the properties you can specify in a Kusto connection string.

--- a/data-explorer/kusto/api/connection-strings/kusto.md
+++ b/data-explorer/kusto/api/connection-strings/kusto.md
@@ -57,6 +57,13 @@ one can use the `Kusto.Data.Common.KustoTrustedEndpoints` class to add additiona
 to the list of trusted endpoints (by using either `SetOverridePolicy` which overrides
 the default policy, or `AddTrustedHosts` which adds new entries to the existing policy.)
 
+```csharp
+Kusto.Data.Common.Impl.WellKnownKustoEndpoints.AddTrustedHosts(
+    new[] {
+        new FastSuffixMatcher.MatchRule("trusted.host", exact: true)
+    });
+```
+
 ## Connection string properties
 
 The following table lists all the properties you can specify in a Kusto connection string.

--- a/data-explorer/kusto/api/connection-strings/kusto.md
+++ b/data-explorer/kusto/api/connection-strings/kusto.md
@@ -65,6 +65,8 @@ Kusto.Data.Common.Impl.WellKnownKustoEndpoints.AddTrustedHosts(
         // Allow services whose DNS name end with ".contoso.com"
         new FastSuffixMatcher.MatchRule(".contoso.com", exact: false),
     });
+```
+
 ## Connection string properties
 
 The following table lists all the properties you can specify in a Kusto connection string.


### PR DESCRIPTION
I added an example of the code AddTrustedHosts usage because it is not obvious which namespace should be used and what kind of input should be passed.
I found this namespace in this changelog:
https://github.com/Azure/azure-kusto-dotnet/blob/0348e6dfcf2c9d2918fedf8712587fd8f5f99321/Microsoft.Azure.Kusto.Data.changelog.md
Not sure if this is what is meant here by 'AddTrustedHosts' but I assumed this method. This is the only place I managed to find it.

Side note: is there a certain minimal version of Microsoft.Azure.Kusto.Data that has "Kusto.Data.Common.Impl.KustoTrustedEndpoints" mentioned in the paragraph?  I am using 10.0.2 and my VS does not see it?