### PR TITLE
Update project-keep-operator.md

### DIFF
--- a/data-explorer/kusto/query/project-keep-operator.md
+++ b/data-explorer/kusto/query/project-keep-operator.md
@@ -7,7 +7,7 @@ ms.date: 10/21/2020
 ---
 # project-keep operator
 
-Select what columns from the input to keep in the output.
+Select what columns from the input to keep in the output using a columnname pattern matcher.
 
 ```kusto
 T | project-keep price, quantity, zz*


### PR DESCRIPTION
Usage of column name pattern matcher is very much needed here to differentiate between project definition and project-keep definition