### PR TITLE
Fix list formatting of arguments in alter-ingestion-mapping-command.md

### DIFF
--- a/data-explorer/kusto/management/alter-ingestion-mapping-command.md
+++ b/data-explorer/kusto/management/alter-ingestion-mapping-command.md
@@ -21,12 +21,11 @@ Alters an existing ingestion mapping that is associated with a specific table/da
 
 ## Arguments
 
-*TableName* - Specify the name of the table.
-*DatabaseName* - Specify the name of the database.
-*MappingKind* - Specify the type of mapping.
-*MappingName* - Specify the name of the mapping.
-*ArrayOfMappingObjects* - An array with one or more mapping objects defined.
-
+* *TableName* - Specify the name of the table.
+* *DatabaseName* - Specify the name of the database.
+* *MappingKind* - Specify the type of mapping.
+* *MappingName* - Specify the name of the mapping.
+* *ArrayOfMappingObjects* - An array with one or more mapping objects defined.
 
 **Example** 
  


### PR DESCRIPTION
Arguments for `.alter ingestion mapping` page are all showing on a single line because of lack of markdown list formatting.

https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/alter-ingestion-mapping-command#arguments

![image](https://user-images.githubusercontent.com/12540534/177922114-f474857c-268c-4e4b-983c-65e7996e05f5.png)


This change makes them look like Arguments on `.create table based-on` page
https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/create-table-based-on-command#arguments

![image](https://user-images.githubusercontent.com/12540534/177921955-ce8a9a80-97de-4ab8-a998-a63b5f431aee.png)


