### PR TITLE
Fix data recoverabilty description in alter-retention-policy-commands

### DIFF
--- a/data-explorer/kusto/management/alter-merge-database-retention-policy-command.md
+++ b/data-explorer/kusto/management/alter-merge-database-retention-policy-command.md
@@ -21,7 +21,7 @@ Change a database's [retention policy](retentionpolicy.md). The retention policy
 
 ### Example
 
-Sets a retention policy with a 10 day soft-delete period, and enable data recoverability:
+Sets a retention policy with a 10 day soft-delete period, and disable data recoverability:
 
 ```kusto
 .alter-merge database MyDatabase policy retention softdelete = 10d recoverability = disabled

--- a/data-explorer/kusto/management/alter-merge-materialized-view-retention-policy-command.md
+++ b/data-explorer/kusto/management/alter-merge-materialized-view-retention-policy-command.md
@@ -20,7 +20,7 @@ Change a materialized-view's [retention policy](retentionpolicy.md). The retenti
 
 ### Example
 
-Sets a retention policy with a 10 day soft-delete period, and enable data recoverability:
+Sets a retention policy with a 10 day soft-delete period, and disable data recoverability:
 
 ```kusto
 .alter-merge materialized-view View1 policy retention softdelete = 10d recoverability = disabled

--- a/data-explorer/kusto/management/alter-merge-table-retention-policy-command.md
+++ b/data-explorer/kusto/management/alter-merge-table-retention-policy-command.md
@@ -20,7 +20,7 @@ Change a table's [retention policy](retentionpolicy.md). The retention policy co
 
 ### Example
 
-Sets a retention policy with a 10 day soft-delete period, and enable data recoverability:
+Sets a retention policy with a 10 day soft-delete period, and disable data recoverability:
 
 ```kusto
 .alter-merge table Table1 policy retention softdelete = 10d recoverability = disabled


### PR DESCRIPTION
The query shows "recoverability = disabled" which means that data can not be recovered after the retention policy (https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/retentionpolicy#the-policy-object).
