### PR TITLE
Update node-ingest to support latest version

### DIFF
--- a/data-explorer/node-ingest-data.md
+++ b/data-explorer/node-ingest-data.md
@@ -64,7 +64,7 @@ const kustoIngestUri = `https://ingest-${cluster}.${region}.kusto.windows.net`;
 const kustoDatabase  = "Weather";
 ```
 
-Now construct the connection string. This example uses device authentication to access the cluster (Make sure to look at the console output to authenticate). You can also use Azure Active Directory application certificate, application key, and user and password.
+Now construct the connection string. This example uses device authentication to access the cluster. Check the console output to complete the authentication. You can also use an Azure Active Directory application certificate, application key, and user and password.
 
 You create the destination table and mapping in a later step.
 


### PR DESCRIPTION
Changes:
- Download specific version, so the guide will always work
- Used old-style imports for older node.js clients
- Fixed deprecated imports
- Used new ctor for IngestionProperties
- Prettier printing