### PR TITLE
Danielle Korn - ILDC Content Team Writing Test

### DIFF
--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -38,24 +38,6 @@ For more information, see [count operator](./countoperator.md).
 Use [project](./projectoperator.md) to pick out only the columns you want. See the following example, which uses both the [project](./projectoperator.md)
 and the [take](./takeoperator.md) operators.
 
-## Filter by Boolean expression: *where*
-
-Let's see only `flood` events in `California` in Feb-2007:
-
-<!-- csl: https://help.kusto.windows.net/Samples -->
-```kusto
-StormEvents
-| where StartTime > datetime(2007-02-01) and StartTime < datetime(2007-03-01)
-| where EventType == 'Flood' and State == 'CALIFORNIA'
-| project StartTime, EndTime , State , EventType , EpisodeNarrative
-```
-
-Here's the output:
-
-|StartTime|EndTime|State|EventType|EpisodeNarrative|
-|---|---|---|---|---|
-|2007-02-19 00:00:00.0000000|2007-02-19 08:00:00.0000000|CALIFORNIA|Flood|A frontal system moving across the Southern San Joaquin Valley brought brief periods of heavy rain to western Kern County in the early morning hours of the 19th. Minor flooding was reported across State Highway 166 near Taft.|
-
 ## Show *n* rows: *take*
 
 Let's see some data. What's in a random sample of five rows?
@@ -112,6 +94,25 @@ StormEvents
 | take 5
 | project  StartTime, EndTime, EventType, EventNarrative
 ```
+
+## Filter by Boolean expression: *where*
+
+Let's see only `flood` events in `California` in Feb-2007:
+
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents
+| where StartTime > datetime(2007-02-01) and StartTime < datetime(2007-03-01)
+| where EventType == 'Flood' and State == 'CALIFORNIA'
+| project StartTime, EndTime , State , EventType , EpisodeNarrative
+```
+
+Here's the output:
+
+|StartTime|EndTime|State|EventType|EpisodeNarrative|
+|---|---|---|---|---|
+|2007-02-19 00:00:00.0000000|2007-02-19 08:00:00.0000000|CALIFORNIA|Flood|A frontal system moving across the Southern San Joaquin Valley brought brief periods of heavy rain to western Kern County in the early morning hours of the 19th. Minor flooding was reported across State Highway 166 near Taft.|
+
 
 ## Compute derived columns: *extend*
 

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -268,73 +268,7 @@ The [bin()](./binfunction.md) function is the same as the [floor()](./floorfunct
 
 <a name="displaychartortable"></a>
 
-## Aggregation functions
-
-The Kusto Query Language provides many [aggregation functions](aggregation-functions.md). 
-
-This section covers one built in aggregation as well as shows how to create your own aggregation using the operators we covered so far.
-
-### Percentiles
-
-What ranges of durations do we find in different percentages of storms?
-
-To get this information, use the preceding query from [Plot a distribution](#plot-a-distribution), but replace `render` with:
-
-```kusto
-| summarize percentiles(duration, 5, 20, 50, 80, 95)
-```
-
-In this case, we didn't use a `by` clause, so the output is a single row:
-
-:::image type="content" source="images/tutorial/summarize-percentiles-duration.png" lightbox="images/tutorial/summarize-percentiles-duration.png" alt-text="Screenshot of a table of results for summarize percentiles by duration.":::
-
-We can see from the output that:
-
-* 5% of storms have a duration of less than 5 minutes.
-* 50% of storms lasted less than 1 hour and 25 minutes.
-* 95% of storms lasted less than 2 hours and 50 minutes.
-
-To get a separate breakdown for each state, use the `state` column separately with both `summarize` operators:
-
-<!-- csl: https://help.kusto.windows.net/Samples -->
-```kusto
-StormEvents
-| extend  duration = EndTime - StartTime
-| where duration > 0s
-| where duration < 3h
-| summarize event_count = count()
-    by bin(duration, 5m), State
-| sort by duration asc
-| summarize percentiles(duration, 5, 20, 50, 80, 95) by State
-```
-
-:::image type="content" source="images/tutorial/summarize-percentiles-state.png" alt-text="Table summarize percentiles duration by state.":::
-
-### Percentages
-
-Using the StormEvents table, calculate the percentage of direct injuries from all injuries:
-
-<!-- csl: https://help.kusto.windows.net/Samples -->
-```kusto
-StormEvents
-| where (InjuriesDirect > 0) and (InjuriesIndirect > 0) 
-| extend Percentage = (  100 * InjuriesDirect / (InjuriesDirect + InjuriesIndirect) )
-| project StartTime, InjuriesDirect, InjuriesIndirect, Percentage
-```
-
-The query removes zero count entries:
-
-|StartTime|InjuriesDirect|InjuriesIndirect|Percentage
-|---|---|---|---|
-|2007-05-01T16:50:00Z|1|1|50|
-|2007-08-10T21:25:00Z|7|2|77|
-|2007-08-23T12:05:00Z|7|22|24|
-|2007-08-23T14:20:00Z|3|2|60|
-|2007-09-10T13:45:00Z|4|1|80|
-|2007-12-06T08:30:00Z|3|3|50|
-|2007-12-08T12:00:00Z|1|1|50|
-
-## Time series visualizations
+## Visualize time series data
 
 This section uses our knowledge of [summarize](#summarize), [render](#render), and bin()](#bin())  to display various types of time series.
 
@@ -439,6 +373,66 @@ StormEvents
 Or, use `| render columnchart`:
 
 :::image type="content" source="images/tutorial/column-event-count-duration.png" alt-text="Screenshot of a column chart for event count timechart by duration.":::
+
+### Percentiles
+
+Let's check what ranges of durations we find in different percentages of storms.
+
+To get this information, use the preceding query from [Plot a distribution](#plot-a-distribution), but replace `render` with:
+
+```kusto
+| summarize percentiles(duration, 5, 20, 50, 80, 95)
+```
+
+In this case, we didn't use a `by` clause, so the output is a single row:
+
+:::image type="content" source="images/tutorial/summarize-percentiles-duration.png" lightbox="images/tutorial/summarize-percentiles-duration.png" alt-text="Screenshot of a table of results for summarize percentiles by duration.":::
+
+The output shows that:
+
+* 5% of storms have a duration of less than 5 minutes.
+* 50% of storms lasted less than 1 hour and 25 minutes.
+* 95% of storms lasted less than 2 hours and 50 minutes.
+
+To get a separate breakdown for each state, use the `state` column separately with both `summarize` operators:
+
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents
+| extend  duration = EndTime - StartTime
+| where duration > 0s
+| where duration < 3h
+| summarize event_count = count()
+    by bin(duration, 5m), State
+| sort by duration asc
+| summarize percentiles(duration, 5, 20, 50, 80, 95) by State
+```
+
+:::image type="content" source="images/tutorial/summarize-percentiles-state.png" alt-text="Table summarize percentiles duration by state.":::
+
+### Percentages
+
+Using the StormEvents table, calculate the percentage of direct injuries from all injuries:
+
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents
+| where (InjuriesDirect > 0) and (InjuriesIndirect > 0) 
+| extend Percentage = (  100 * InjuriesDirect / (InjuriesDirect + InjuriesIndirect) )
+| project StartTime, InjuriesDirect, InjuriesIndirect, Percentage
+```
+
+The query removes zero count entries:
+
+|StartTime|InjuriesDirect|InjuriesIndirect|Percentage
+|---|---|---|---|
+|2007-05-01T16:50:00Z|1|1|50|
+|2007-08-10T21:25:00Z|7|2|77|
+|2007-08-23T12:05:00Z|7|22|24|
+|2007-08-23T14:20:00Z|3|2|60|
+|2007-09-10T13:45:00Z|4|1|80|
+|2007-12-06T08:30:00Z|3|3|50|
+|2007-12-08T12:00:00Z|1|1|50|
 
 ## Join data from two tables
 
@@ -577,11 +571,15 @@ Run these queries by using Log Analytics in the Azure portal. Log Analytics is a
 
 ## Learn common operators 
 
-## Count rows
+A Kusto query consists of a data source (usually a table name) followed by one or more pairs of the pipe character (`|`) and some tabular operator. This section reviews some of the common [query operators](queries.md).
 
-The [InsightsMetrics](/azure/azure-monitor/reference/tables/insightsmetrics) table contains performance data that's collected by insights such as Azure Monitor for VMs and Azure Monitor for containers. To find out how large the table is, we'll pipe its content into an operator that counts rows.
+### count
 
-A query is a data source (usually a table name), optionally  followed by one or more pairs of the pipe character and some tabular operator. In this case, all records from the `InsightsMetrics` table are returned and then sent to the [count operator](./countoperator.md). The `count` operator displays the results because the operator is the last command in the query.
+[count](./countoperator.md): returns the number of rows in the table.
+
+The [InsightsMetrics](/azure/azure-monitor/reference/tables/insightsmetrics) table contains performance data that's collected by insights such as Azure Monitor for VMs and Azure Monitor for containers.
+
+Let's use the [count](./countoperator.md) operator to check the size of the `InsightsMetrics` table:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -594,14 +592,13 @@ Here's the output:
 |-----|
 |1,263,191|
 
-## Filter by Boolean expression: *where*
+## where
 
-The [AzureActivity](/azure/azure-monitor/reference/tables/azureactivity) table has entries from the Azure activity log, which provides insight into subscription-level or management group-level events occuring in Azure. Let's see only `Critical` entries during a specific week.
+[where](./whereoperator.md): filters by Boolean expression.
 
-The [where](./whereoperator.md) operator is common in the Kusto Query Language. `where` filters a table to rows that match specific criteria. The following example uses multiple commands. First, the query retrieves all records for the table. Then, it filters the data for only records that are in the time range. Finally, it filters those results for only records that have a `Critical` level.
+The [AzureActivity](/azure/azure-monitor/reference/tables/azureactivity) table has entries from the Azure activity log, which provides insight into subscription-level or management group-level events occuring in Azure. 
 
-> [!NOTE]
-> In addition to specifying a filter in your query by using the `TimeGenerated` column, you can specify the time range in Log Analytics. For more information, see [Log query scope and time range in Azure Monitor Log Analytics](/azure/azure-monitor/log-query/scope).
+Let's see only `Critical` entries during a specific week:
 
 ```kusto
 AzureActivity
@@ -609,11 +606,18 @@ AzureActivity
 | where Level == 'Critical'
 ```
 
+> [!TIP]
+> In addition to specifying a filter in your query by using the `TimeGenerated` column, you can specify the time range in Log Analytics. For more information, see [Log query scope and time range in Azure Monitor Log Analytics](/azure/azure-monitor/log-query/scope).
+
+The above example uses multiple commands. First, the query retrieves all records for the table. Then, it filters the data for only records that are in the time range. Finally, it filters those results for only records that have a `Critical` level.
+
 :::image type="content" source="images/tutorial/azure-monitor-where-results.png" lightbox="images/tutorial/azure-monitor-where-results.png" alt-text="Screenshot that shows the results of the where operator example.":::
 
-## Select a subset of columns: *project*
+## project
 
-Use [project](./projectoperator.md) to include only the columns you want. Building on the preceding example, let's limit the output to certain columns:
+[project](./projectoperator.md): selects a subset of columns.
+
+Use the [project](./projectoperator.md) operator to pick the columns you want to include in the query result. Building on the preceding example, let's limit the output to certain columns:
 
 ```kusto
 AzureActivity
@@ -624,9 +628,13 @@ AzureActivity
 
 :::image type="content" source="images/tutorial/azure-monitor-project-results.png" lightbox="images/tutorial/azure-monitor-project-results.png" alt-text="Screenshot that shows the results of the project operator example.":::
 
-## Show *n* rows: *take*
+## take
 
-[NetworkMonitoring](/azure/azure-monitor/reference/tables/networkmonitoring) contains monitoring data for Azure virtual networks. Let's use the [take](./takeoperator.md) operator to look at 10 random sample rows in that table. The [take](./takeoperator.md) shows some rows from a table in no particular order:
+[take](./takeoperator.md): shows *n* rows.
+
+The [NetworkMonitoring](/azure/azure-monitor/reference/tables/networkmonitoring) table contains monitoring data for Azure virtual networks.  
+
+Let's use the [take](./takeoperator.md) operator to look at 10 random sample rows in that table. 
 
 ```kusto
 NetworkMonitoring
@@ -636,9 +644,13 @@ NetworkMonitoring
 
 :::image type="content" source="images/tutorial/azure-monitor-take-results.png" lightbox="images/tutorial/azure-monitor-take-results.png" alt-text="Screenshot that shows the results of the take operator example.":::
 
-## Order results: *sort*, *top*
+But [take](./takeoperator.md) shows rows from the table in no particular order, so let's sort them.
 
-Instead of random records, we can return the latest five records by first sorting by time:
+### sort
+
+[sort](./sortoperator.md): orders results by the given column.
+
+Instead of random records, let's return the latest five records by first sorting by time:
 
 ```kusto
 NetworkMonitoring
@@ -647,7 +659,9 @@ NetworkMonitoring
 | project TimeGenerated, Computer, SourceNetwork, DestinationNetwork, HighLatency, LowLatency
 ```
 
-You can get this exact behavior by instead using the [top](./topoperator.md) operator:
+### top 
+
+Achieve the same result as the previous `sort` example by using the [top](./topoperator.md) operator:
 
 ```kusto
 NetworkMonitoring
@@ -657,9 +671,11 @@ NetworkMonitoring
 
 :::image type="content" source="images/tutorial/azure-monitor-top-results.png" lightbox="images/tutorial/azure-monitor-top-results.png" alt-text="Screenshot that shows the results of the top operator example.":::
 
-## Compute derived columns: *extend*
+### extend
 
-The [extend](./projectoperator.md) operator is similar to [project](./projectoperator.md), but it adds to the set of columns instead of replacing them. You can use both operators to create a new column based on a computation on each row.
+[extend](./extendoperator.md): computes derived columns.
+
+The [extend](./projectoperator.md) operator is similar to [project](./projectoperator.md), but it adds to the set of columns instead of replacing them. Use both operators to create a new column based on a computation on each row.
 
 The [Perf](/azure/azure-monitor/reference/tables/perf) table has performance data that's collected from virtual machines that run the Log Analytics agent.
 
@@ -672,16 +688,18 @@ Perf
 
 :::image type="content" source="images/tutorial/azure-monitor-extend-results.png" lightbox="images/tutorial/azure-monitor-extend-results.png" alt-text="Screenshot that shows the results of the extend operator example.":::
 
-## Aggregate groups of rows: *summarize*
+### summarize
 
-The [summarize](./summarizeoperator.md) operator groups together rows that have the same values in the `by` clause. Then, it uses an aggregation function like `count` to combine each group in a single row. A range of [aggregation functions](aggregation-functions.md) are available. You can use several aggregation functions in one `summarize` operator to produce several computed columns.
+[summarize](./summarizeoperator.md): produces a table that aggregates the content of the input table.
 
-The [SecurityEvent](/azure/azure-monitor/reference/tables/securityevent) table contains security events like logons and processes that started on monitored computers. You can count how many events of each level occurred on each computer. In this example, a row is produced for each computer and level combination. A column contains the count of events.
+The [SecurityEvent](/azure/azure-monitor/reference/tables/securityevent) table contains security events like logons and processes that started on monitored computers. Count how many events of each level occurred on each computer: 
 
 ```kusto
 SecurityEvent
 | summarize count() by Computer, Level
 ```
+
+The [summarize](./summarizeoperator.md) operator groups together rows that have the same values in the `by` clause. Then, it uses an aggregation function like `count` to combine each group in a single row. A range of [aggregation functions](aggregation-functions.md) are available. Use several aggregation functions in one `summarize` operator to produce several computed columns.
 
 :::image type="content" source="images/tutorial/azure-monitor-summarize-count-results.png" lightbox="images/tutorial/azure-monitor-summarize-count-results.png" alt-text="Screenshot that shows the results of the summarize count operator example.":::
 

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -12,7 +12,7 @@ zone_pivot_groups: kql-flavors
 
 ::: zone pivot="azuredataexplorer"
 
-The best way to learn about the Kusto Query Language is to look at some basic queries to get a feel for the language. Follow along in this tutorial by running the example queries on this [database with sample data](https://help.kusto.windows.net/Samples). We will mostly use the `StormEvents` table, which provides information about past storms in the United States.
+The best way to learn the Kusto Query Language is to look at some basic queries to get a feel for the language. Follow along in this tutorial by running the example queries on this [database with sample data](https://help.kusto.windows.net/Samples). We will mostly use the `StormEvents` table, which provides information about past storms in the United States.
 
 ## Learn common operators
 
@@ -562,9 +562,11 @@ For more information about combining data from several databases in a query, see
 
 ::: zone pivot="azuremonitor"
 
-The best way to learn about the Azure Data Explorer Query Language is to look at some basic queries to get a "feel" for the language. These queries are similar to queries in the Azure Data Explorer tutorial, but use data from common tables in an Azure Log Analytics workspace.
+The best way to learn the Kusto Query Language is to look at some basic queries to get a feel for the language. 
 
-Run these queries by using Log Analytics in the Azure portal. Log Analytics is a tool you can use to write log queries. Use log data in Azure Monitor, and then evaluate log query results. If you aren't familiar with Log Analytics, complete the [Log Analytics tutorial](/azure/azure-monitor/log-query/log-analytics-tutorial).
+All queries in this tutorial use the [Log Analytics demo environment](https://ms.portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/DemoLogsBlade). If you use your own environment, you might not have some of the tables that are used here.
+
+Run the queries in this tutorial using Log Analytics in the Azure portal. Log Analytics is a tool to write log queries. If you aren't familiar with Log Analytics, complete the [Log Analytics tutorial](/azure/azure-monitor/log-query/log-analytics-tutorial).
 
 >[!NOTE]
 > Because the data in the demo environment isn't static, the results of your queries might vary slightly from the results shown here.

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -12,13 +12,16 @@ zone_pivot_groups: kql-flavors
 
 ::: zone pivot="azuredataexplorer"
 
-The best way to learn about the Kusto Query Language is to look at some basic queries to get a "feel" for the language. We recommend using a [database with some sample data](https://help.kusto.windows.net/Samples). The queries that are demonstrated in this tutorial should run on that database. The `StormEvents` table in the sample database provides some information about storms that happened in the United States.
+The best way to learn about the Kusto Query Language is to look at some basic queries to get a feel for the language. We recommend using a [database with some sample data](https://help.kusto.windows.net/Samples). The queries in this tutorial are based on that database. We will mostly use the `StormEvents` table, which provides information about past storms in the United States.
 
-## Count rows
+## Common query operators
 
-Our example database has a table called `StormEvents`. we want to find out how large the table is. So we'll pipe its content into an operator that counts the rows in the table.
+A Kusto query consists of a data source (usually a table name) followed by one or more pairs of the pipe character and some tabular operator. We will cover many of the operators in this section.
 
-*Syntax note*: A query is a data source (usually a table name), optionally followed by one or more pairs of the pipe character and some tabular operator.
+### count 
+#### Return the number of rows in a table
+
+Let's use the [count](./countoperator.md) operator to check the size of the `StormEvents` table:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -31,14 +34,14 @@ Here's the output:
 |-----|
 |59066|
 
-For more information, see [count operator](./countoperator.md).
+### project
+#### Select a subset of columns
 
-## Select a subset of columns: *project*
-
-Use [project](./projectoperator.md) to pick out only the columns you want. See the following example, which uses both the [project](./projectoperator.md)
+Use the [project](./projectoperator.md) operator to pick the columns you want. See the following example, which uses both the [project](./projectoperator.md)
 and the [take](./takeoperator.md) operators.
 
-## Show *n* rows: *take*
+### take 
+#### Show *n* rows
 
 Let's see some data. What's in a random sample of five rows?
 
@@ -59,14 +62,19 @@ Here's the output:
 |2007-12-20 07:50:00.0000000|2007-12-20 07:53:00.0000000|Thunderstorm Wind|MISSISSIPPI|Numerous large trees were blown down with some down on power lines. Damage occurred in eastern Adams county.|
 |2007-12-30 16:00:00.0000000|2007-12-30 16:05:00.0000000|Thunderstorm Wind|GEORGIA|The county dispatch reported several trees were blown down along Quincey Batten Loop near State Road 206. The cost of tree removal was estimated.|
 
-But [take](./takeoperator.md) shows rows from the table in no particular order, so let's sort them. ([limit](./takeoperator.md) is an alias for [take](./takeoperator.md) and has the same effect.)
+But [take](./takeoperator.md) shows rows from the table in no particular order, so let's sort them.
 
-## Order results: *sort*, *top*
+> [!NOTE]
+> [limit](./takeoperator.md) is an alias for [take](./takeoperator.md) and has the same effect.
 
-* *Syntax note*: Some operators have parameters that are introduced by keywords like `by`.
-* In the following example, `desc` orders results in descending order and `asc` orders results in ascending order.
+### top
+#### Show *n* rows ordered by given column
 
-Show me the first *n* rows, ordered by a specific column:
+*Syntax note*: Some operators, such as `top` and `sort`, require parameters that are introduced by keywords like `by`.
+
+In the following example, `desc` orders results in descending order and `asc` orders results in ascending order.
+
+Show the first *n* rows, ordered by the StartTime column:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -85,7 +93,10 @@ Here's the output:
 |2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
 |2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
 
-You can achieve the same result by using [sort](./sortoperator.md), and then [take](./takeoperator.md):
+### sort
+#### Order results
+
+Achieve the same result as above by using [sort](./sortoperator.md) followed by [take](./takeoperator.md):
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -95,7 +106,8 @@ StormEvents
 | project  StartTime, EndTime, EventType, State, EventNarrative
 ```
 
-## Filter by Boolean expression: *where*
+### where
+#### Filter by Boolean expression
 
 Let's see only `flood` events in `California` in Feb-2007:
 
@@ -114,7 +126,8 @@ Here's the output:
 |2007-02-19 00:00:00.0000000|2007-02-19 08:00:00.0000000|CALIFORNIA|Flood|A frontal system moving across the Southern San Joaquin Valley brought brief periods of heavy rain to western Kern County in the early morning hours of the 19th. Minor flooding was reported across State Highway 166 near Taft.|
 
 
-## Compute derived columns: *extend*
+### extend
+#### Compute derived columns
 
 Create a new column by computing a value in every row:
 
@@ -155,9 +168,10 @@ Here's the output:
 
 [Scalar expressions](./scalar-data-types/index.md) can include all the usual operators (`+`, `-`, `*`, `/`, `%`), and a range of useful functions are available.
 
-## Aggregate groups of rows: *summarize*
+### summarize
+#### Aggregate groups of rows
 
-Count the number of events occur in each state:
+Count the number of events that occur in each state:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -165,9 +179,10 @@ StormEvents
 | summarize event_count = count() by State
 ```
 
-[summarize](./summarizeoperator.md) groups together rows that have the same values in the `by` clause, and then uses an aggregation function (for example, `count`) to combine each group in a single row. In this case, there's a row for each state and a column for the count of rows in that state.
+[summarize](./summarizeoperator.md) groups together rows that have the same values in the `by` clause, and then it uses an aggregation function (for example, `count`) to combine each group in a single row. 
+In this case, there's a row for each state and a column for the count of rows in that state.
 
-A range of [aggregation functions](aggregation-functions.md) are available. You can use several aggregation functions in one `summarize` operator to produce several computed columns. For example, we could get the count of storms per state, and the sum of unique types of storm per state. Then, we could use [top](./topoperator.md) to get the most storm-affected states:
+A range of [aggregation functions](aggregation-functions.md) are available. Use several aggregation functions in one `summarize` operator to produce several computed columns. For example, get the count of storms per state and the sum of unique types of storm per state. Then, use [top](./topoperator.md) to get the most storm-affected states:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -192,9 +207,9 @@ In the results of a `summarize` operator:
 * Each computed expression has a column.
 * Each combination of `by` values has a row.
 
-## Summarize by scalar values
+#### Summarize by scalar values
 
-You can use scalar (numeric, time, or interval) values in the `by` clause, but you'll want to put the values into bins by using the [bin()](./binfunction.md) function:
+When using scalar (numeric, time, or interval) values in the `by` clause, put the values into bins with the [bin()](./binfunction.md) function:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -215,13 +230,14 @@ The query reduces all the timestamps to intervals of one day:
 |2007-02-19 00:00:00.0000000|52|
 |2007-02-20 00:00:00.0000000|60|
 
-The [bin()](./binfunction.md) is the same as the [floor()](./floorfunction.md) function in many languages. It simply reduces every value to the nearest multiple of the modulus that you supply, so that [summarize](./summarizeoperator.md) can assign the rows to groups.
+The [bin()](./binfunction.md) function is the same as the [floor()](./floorfunction.md) function in many languages. It simply reduces every value to the nearest multiple of the modulus that you supply. This allows [summarize](./summarizeoperator.md) to assign the rows to groups.
 
 <a name="displaychartortable"></a>
 
-## Display a chart or table: *render*
+### render
+##### Display a chart or table
 
-You can project two columns and use them as the x-axis and the y-axis of a chart:
+Project two columns and use them as the x-axis and the y-axis of a chart:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -235,7 +251,7 @@ StormEvents
 
 :::image type="content" source="images/tutorial/event-counts-state.png" alt-text="Screenshot that shows a column chart of storm event counts by state.":::
 
-Although we removed `mid` in the `project` operation, we still need it if we want the chart to display the states in that order.
+We did not include `mid` in the `project` operation. This way the `mid` data is not visually represented in the chart, yet we still display the states in order based on their `mid` values.
 
 Strictly speaking, `render` is a feature of the client rather than part of the query language. Still, it's integrated into the language, and it's useful for envisioning your results.
 

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -340,6 +340,27 @@ StormEvents
 
 :::image type="content" source="images/tutorial/join-events-lightning-avalanche.png" alt-text="Screenshot that shows joining the events lightning and avalanche.":::
 
+## Assign a result to a variable: *let*
+
+Use [let](./letstatement.md) to separate out the parts of the query expression in the preceding `join` example. The results are unchanged:
+
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+let LightningStorms = 
+    StormEvents
+    | where EventType == "Lightning";
+let AvalancheStorms = 
+    StormEvents
+    | where EventType == "Avalanche";
+LightningStorms 
+| join (AvalancheStorms) on State
+| distinct State
+```
+
+> [!TIP]
+> In Kusto Explorer, to execute the entire query, don't add blank lines between parts of the query.
+> Any two statements must be separated by a semicolon.
+
 ## User session example of *join*
 
 This section doesn't use the `StormEvents` table.
@@ -449,27 +470,6 @@ The query removes zero count entries:
 |2007-09-10T13:45:00Z|4|1|80|
 |2007-12-06T08:30:00Z|3|3|50|
 |2007-12-08T12:00:00Z|1|1|50|
-
-## Assign a result to a variable: *let*
-
-Use [let](./letstatement.md) to separate out the parts of the query expression in the preceding `join` example. The results are unchanged:
-
-<!-- csl: https://help.kusto.windows.net/Samples -->
-```kusto
-let LightningStorms = 
-    StormEvents
-    | where EventType == "Lightning";
-let AvalancheStorms = 
-    StormEvents
-    | where EventType == "Avalanche";
-LightningStorms 
-| join (AvalancheStorms) on State
-| distinct State
-```
-
-> [!TIP]
-> In Kusto Explorer, to execute the entire query, don't add blank lines between parts of the query.
-> Any two statements must be separated by a semicolon.
 
 ## Combine data from several databases in a query
 

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -102,7 +102,7 @@ Let's see only `flood` events in `California` in Feb-2007:
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
 StormEvents
-| where StartTime > datetime(2007-02-01) and StartTime < datetime(2007-03-01)
+| where StartTime >= datetime(2007-02-01) and StartTime < datetime(2007-03-01)
 | where EventType == 'Flood' and State == 'CALIFORNIA'
 | project StartTime, EndTime , State , EventType , EpisodeNarrative
 ```

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -19,7 +19,8 @@ The best way to learn about the Kusto Query Language is to look at some basic qu
 A Kusto query consists of a data source (usually a table name) followed by one or more pairs of the pipe character and some tabular operator. We will cover many of the operators in this section.
 
 ### count 
-#### Return the number of rows in a table
+
+[count](./countoperator.md): returns the number of rows in the table.
 
 Let's use the [count](./countoperator.md) operator to check the size of the `StormEvents` table:
 
@@ -35,13 +36,15 @@ Here's the output:
 |59066|
 
 ### project
-#### Select a subset of columns
+
+[project](./projectoperator.md): selects a subset of columns.
 
 Use the [project](./projectoperator.md) operator to pick the columns you want. See the following example, which uses both the [project](./projectoperator.md)
 and the [take](./takeoperator.md) operators.
 
 ### take 
-#### Show *n* rows
+
+[take](./takeoperator.md): shows *n* rows.
 
 Let's see some data. What's in a random sample of five rows?
 
@@ -68,7 +71,8 @@ But [take](./takeoperator.md) shows rows from the table in no particular order, 
 > [limit](./takeoperator.md) is an alias for [take](./takeoperator.md) and has the same effect.
 
 ### top
-#### Show *n* rows ordered by given column
+
+[top](./topoperator.md): shows *n* rows ordered by given column.
 
 *Syntax note*: Some operators, such as `top` and `sort`, require parameters that are introduced by keywords like `by`.
 
@@ -94,7 +98,8 @@ Here's the output:
 |2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
 
 ### sort
-#### Order results
+
+[sort](./sortoperator.md): orders results in ascending or descending order.
 
 Achieve the same result as above by using [sort](./sortoperator.md) followed by [take](./takeoperator.md):
 
@@ -107,7 +112,8 @@ StormEvents
 ```
 
 ### where
-#### Filter by Boolean expression
+
+[where](./whereoperator.md): filters by Boolean expression.
 
 Let's see only `flood` events in `California` in Feb-2007:
 
@@ -127,7 +133,8 @@ Here's the output:
 
 
 ### extend
-#### Compute derived columns
+
+[extend](./extendoperator.md): computes derived columns.
 
 Create a new column by computing a value in every row:
 
@@ -169,7 +176,8 @@ Here's the output:
 [Scalar expressions](./scalar-data-types/index.md) can include all the usual operators (`+`, `-`, `*`, `/`, `%`), and a range of useful functions are available.
 
 ### summarize
-#### Aggregate groups of rows
+
+[summarize](./summarizeoperator.md): aggregates groups of rows.
 
 Count the number of events that occur in each state:
 
@@ -235,7 +243,8 @@ The [bin()](./binfunction.md) function is the same as the [floor()](./floorfunct
 <a name="displaychartortable"></a>
 
 ### render
-##### Display a chart or table
+
+[render](./renderoperator.md): displays a chart or table.
 
 Project two columns and use them as the x-axis and the y-axis of a chart:
 

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -92,7 +92,7 @@ You can achieve the same result by using [sort](./sortoperator.md), and then [ta
 StormEvents
 | sort by StartTime desc
 | take 5
-| project  StartTime, EndTime, EventType, EventNarrative
+| project  StartTime, EndTime, EventType, State, EventNarrative
 ```
 
 ## Filter by Boolean expression: *where*

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -79,11 +79,11 @@ Here's the output:
 
 |StartTime|EndTime|EventType|State|EventNarrative|
 |---|---|---|---|---|
-|2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
-|2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
-|2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
 |2007-12-31 23:53:00.0000000|2007-12-31 23:53:00.0000000|High Wind|CALIFORNIA|North to northeast winds gusting to around 58 mph were reported in the mountains of Ventura county.|
 |2007-12-31 23:53:00.0000000|2007-12-31 23:53:00.0000000|High Wind|CALIFORNIA|The Warm Springs RAWS sensor reported northerly winds gusting to 58 mph.|
+|2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
+|2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
+|2007-12-31 22:30:00.0000000|2007-12-31 23:59:00.0000000|Winter Storm|MICHIGAN|This heavy snow event continued into the early morning hours on New Year's Day.|
 
 You can achieve the same result by using [sort](./sortoperator.md), and then [take](./takeoperator.md):
 

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -12,7 +12,7 @@ zone_pivot_groups: kql-flavors
 
 ::: zone pivot="azuredataexplorer"
 
-The best way to learn the Kusto Query Language is to look at some basic queries to get a feel for the language. Follow along in this tutorial by running the example queries on this [database with sample data](https://help.kusto.windows.net/Samples). We will mostly use the `StormEvents` table, which provides information about past storms in the United States.
+The best way to learn the Kusto Query Language is to look at some basic queries to get a feel for the language. Follow along in this tutorial by running the example queries on this [database with sample data](https://help.kusto.windows.net/Samples). We will mostly use the `StormEvents` table which provides information about past storms in the United States.
 
 ## Learn common operators
 
@@ -39,7 +39,7 @@ Here's the output:
 
 [project](./projectoperator.md): selects a subset of columns.
 
-Use the [project](./projectoperator.md) operator to pick the columns you want to include in the query result. See the following example, which uses both the [project](./projectoperator.md)
+Use [project](./projectoperator.md) to pick the columns you want to include in the query result. See the following example, which uses both the [project](./projectoperator.md)
 and the [take](./takeoperator.md) operators.
 
 ### take 
@@ -74,7 +74,7 @@ But [take](./takeoperator.md) shows rows from the table in no particular order, 
 
 [top](./topoperator.md): shows *n* rows ordered by given column.
 
-Indicate the column to base the ordering on with the `by` keyword. Then, specify whether to order in ascending order (`asc`) or descending order (`desc`).
+Use the `by` keyword to indicate the column on which you want to base the order of the results. Then, specify whether to order in ascending order (`asc`) or descending order (`desc`).
 
 Show the first *n* rows, ordered by the StartTime column:
 
@@ -185,8 +185,7 @@ StormEvents
 | summarize event_count = count() by State
 ```
 
-[summarize](./summarizeoperator.md) groups together rows that have the same values in the `by` clause, and then it uses an aggregation function (for example, `count`) to combine each group in a single row. 
-In this case, there's a row for each state and a column for the count of rows in that state.
+[summarize](./summarizeoperator.md) groups together rows that have the same values in the `by` clause, and then it uses an aggregation function (for example, `count`) to combine each group in a single row. In this case, there's a row for each state and a column for the count of rows in that state.
 
 A range of [aggregation functions](aggregation-functions.md) are available. Use several aggregation functions in one `summarize` operator to produce several computed columns. For example, get the count of storms per state and the sum of unique types of storm per state. Then, use [top](./topoperator.md) to get the most storm-affected states:
 
@@ -492,7 +491,7 @@ Use [let](./letstatement.md) to make queries easier to read and manage.
 
 [let](./letstatement.md): sets a variable name equal to an expression or a function.
 
-Let's separate out the parts of the query expression in the first `join` example with `let`. The results are unchanged:
+Here we separate out the parts of the query expression in the first `join` example with `let`. The results are unchanged.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -564,9 +563,9 @@ For more information about combining data from several databases in a query, see
 
 The best way to learn the Kusto Query Language is to look at some basic queries to get a feel for the language. 
 
-All queries in this tutorial use the [Log Analytics demo environment](https://ms.portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/DemoLogsBlade). If you use your own environment, you might not have some of the tables that are used here.
+Run the queries in this tutorial using Log Analytics in the Azure portal. Log Analytics is a tool to write log queries. If you aren't familiar with Log Analytics, complete the [Log Analytics tutorial](/azure/azure-monitor/log-query/log-analytics-tutorial). 
 
-Run the queries in this tutorial using Log Analytics in the Azure portal. Log Analytics is a tool to write log queries. If you aren't familiar with Log Analytics, complete the [Log Analytics tutorial](/azure/azure-monitor/log-query/log-analytics-tutorial).
+All queries in this tutorial use the [Log Analytics demo environment](https://ms.portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/DemoLogsBlade).
 
 >[!NOTE]
 > Because the data in the demo environment isn't static, the results of your queries might vary slightly from the results shown here.
@@ -594,7 +593,7 @@ Here's the output:
 |-----|
 |1,263,191|
 
-## where
+### where
 
 [where](./whereoperator.md): filters by Boolean expression.
 
@@ -602,24 +601,24 @@ The [AzureActivity](/azure/azure-monitor/reference/tables/azureactivity) table h
 
 Let's see only `Critical` entries during a specific week:
 
+> [!TIP]
+> In addition to specifying a filter in your query by using the `TimeGenerated` column, you can specify the time range in Log Analytics. For more information, see [Log query scope and time range in Azure Monitor Log Analytics](/azure/azure-monitor/log-query/scope).
+
 ```kusto
 AzureActivity
 | where TimeGenerated > datetime(10-01-2020) and TimeGenerated < datetime(10-07-2020)
 | where Level == 'Critical'
 ```
 
-> [!TIP]
-> In addition to specifying a filter in your query by using the `TimeGenerated` column, you can specify the time range in Log Analytics. For more information, see [Log query scope and time range in Azure Monitor Log Analytics](/azure/azure-monitor/log-query/scope).
-
 The above example uses multiple commands. First, the query retrieves all records for the table. Then, it filters the data for only records that are in the time range. Finally, it filters those results for only records that have a `Critical` level.
 
 :::image type="content" source="images/tutorial/azure-monitor-where-results.png" lightbox="images/tutorial/azure-monitor-where-results.png" alt-text="Screenshot that shows the results of the where operator example.":::
 
-## project
+### project
 
 [project](./projectoperator.md): selects a subset of columns.
 
-Use the [project](./projectoperator.md) operator to pick the columns you want to include in the query result. Building on the preceding example, let's limit the output to certain columns:
+Apply the [project](./projectoperator.md) operator to pick the columns you want to include in the query result. Building on the preceding example, let's limit the output to certain columns:
 
 ```kusto
 AzureActivity
@@ -630,7 +629,7 @@ AzureActivity
 
 :::image type="content" source="images/tutorial/azure-monitor-project-results.png" lightbox="images/tutorial/azure-monitor-project-results.png" alt-text="Screenshot that shows the results of the project operator example.":::
 
-## take
+### take
 
 [take](./takeoperator.md): shows *n* rows.
 
@@ -709,7 +708,7 @@ The [summarize](./summarizeoperator.md) operator groups together rows that have 
 
 When aggregating by scalar values, like numbers and time values, use the [bin()](./binfunction.md) function to group rows into distinct sets of data. 
 
-Otherwise, if you aggregate by `TimeGenerated`, you'll get a row for most time values. The `bin()` function consolidates values per hour or day.
+For example, if you aggregate by `TimeGenerated`, you'll get a row for most time values. Use the `bin()` function to consolidate values per hour or day.
 
 The [InsightsMetrics](/azure/azure-monitor/reference/tables/insightsmetrics) table contains performance data that's organized according to insights from Azure Monitor for VMs and Azure Monitor for containers. 
 
@@ -779,7 +778,7 @@ VMComputer
 
 Use [let](./letstatement.md) to make queries easier to read and manage. The [let](./letstatement.md) statement assigns the results of a query to a variable that can be used later. 
 
-Let's rewrite the query in the preceding example with [let](./letstatement.md):
+Here we rewrite the query in the preceding example with [let](./letstatement.md):
 
 ```kusto
 let PhysicalComputer = VMComputer

--- a/data-explorer/kusto/query/tutorial.md
+++ b/data-explorer/kusto/query/tutorial.md
@@ -14,7 +14,7 @@ zone_pivot_groups: kql-flavors
 
 The best way to learn about the Kusto Query Language is to look at some basic queries to get a feel for the language. Follow along in this tutorial by running the example queries on this [database with sample data](https://help.kusto.windows.net/Samples). We will mostly use the `StormEvents` table, which provides information about past storms in the United States.
 
-## Common operators
+## Learn common operators
 
 A Kusto query consists of a data source (usually a table name) followed by one or more pairs of the pipe character (`|`) and some tabular operator. This section reviews some of the common [query operators](queries.md).
 
@@ -39,14 +39,14 @@ Here's the output:
 
 [project](./projectoperator.md): selects a subset of columns.
 
-Use the [project](./projectoperator.md) operator to pick the columns you want. See the following example, which uses both the [project](./projectoperator.md)
+Use the [project](./projectoperator.md) operator to pick the columns you want to include in the query result. See the following example, which uses both the [project](./projectoperator.md)
 and the [take](./takeoperator.md) operators.
 
 ### take 
 
 [take](./takeoperator.md): shows *n* rows.
 
-Let's see some data. What's in a random sample of five rows?
+Let's see some data. Here is what's in a random sample of five rows:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -175,7 +175,7 @@ Here's the output:
 
 ### summarize
 
-[summarize](./summarizeoperator.md): aggregates groups of rows.
+[summarize](./summarizeoperator.md): produces a table that aggregates the content of the input table.
 
 Count the number of events that occur in each state:
 
@@ -235,15 +235,15 @@ StormEvents
 
 We did not include `mid` in the `project` operation. This way the `mid` data is not visually represented in the chart, yet we still display the states in order based on their `mid` values.
 
-## Scalar functions
+## Aggregate by scalar values
 
-We will only review one of the most helpful scalar functions in this section. To experiement with more, check out the detailed [scalar functions](scalarfunctions.md) section of our docs.
+When aggregating by scalar values, like numbers and time values, use the [bin()](./binfunction.md) function to group rows into distinct sets of data.
 
 ### bin()
 
 [bin()](./binfunction.md): rounds values down to an integer multiple of a given bin size.
 
-Put values into bins when using scalar (numeric, time, or interval) values in the `by` clause with the [bin()](./binfunction.md) function:
+The following query determines the storm event count per day.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -371,7 +371,7 @@ Notice that `render timechart` uses the first column as the x-axis, and then dis
 
 ### Daily average cycle
 
-How does activity vary over the average day?
+Let's explore how activity varies over the average day.
 
 Count events by the time modulo one day, binned into hours. Here, we use `floor` instead of `bin`:
 
@@ -392,7 +392,7 @@ Currently, `render` doesn't label durations properly, but we could use `| render
 
 ### Compare multiple daily series
 
-How does activity vary over the time of day in different states?
+The following query shows how storm activity varies over the time of day in different states.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -420,7 +420,7 @@ StormEvents
 
 ### Plot a distribution
 
-How many storms are there of different lengths?
+The following query calculates how many storms there are of different lengths.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -436,11 +436,11 @@ StormEvents
 
 :::image type="content" source="images/tutorial/event-count-duration.png" alt-text="Screenshot of timechart results for event count by duration.":::
 
-Or, you can use `| render columnchart`:
+Or, use `| render columnchart`:
 
 :::image type="content" source="images/tutorial/column-event-count-duration.png" alt-text="Screenshot of a column chart for event count timechart by duration.":::
 
-## Data joins
+## Join data from two tables
 
 This section covers how to join data across tables.
 
@@ -448,9 +448,7 @@ This section covers how to join data across tables.
 
 #### Example: find states with two specific storm events
 
-How would you find two specific event types and in which state each of them happened?
-
-Pull storm events with the first `EventType` and the second `EventType`, and then join the two sets on `State`:
+Find two specific event types and in which state each of them happened by pulling storm events with the first `EventType` and the second `EventType`, and then join the two sets on `State`:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -494,13 +492,13 @@ Events
 >[!TIP]
 > It's a good practice to use `project` to select just the relevant columns before you perform the join. In the above example, we also rename the `timestamp` column in the same clause.
 
-## Variable assignment in queries
+## Assign a result to a variable
 
-This section shows how to break complex query expressions into chunks using [let](letstatement.md). This improves readability and reusability, since we can use the variable in more than one query.
+Use [let](./letstatement.md) to make queries easier to read and manage.
 
 [let](./letstatement.md): sets a variable name equal to an expression or a function.
 
-Let's use [let](./letstatement.md) to separate out the parts of the query expression in the first `join` example. The results are unchanged:
+Let's separate out the parts of the query expression in the first `join` example with `let`. The results are unchanged:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -519,7 +517,7 @@ LightningStorms
 > In Kusto Explorer, to execute the entire query, don't add blank lines between parts of the query.
 > Any two statements must be separated by a semicolon.
 
-## Cross-database queries
+## Query across databases
 
 To access a table in a different database, use the following syntax:
 
@@ -574,7 +572,10 @@ The best way to learn about the Azure Data Explorer Query Language is to look at
 
 Run these queries by using Log Analytics in the Azure portal. Log Analytics is a tool you can use to write log queries. Use log data in Azure Monitor, and then evaluate log query results. If you aren't familiar with Log Analytics, complete the [Log Analytics tutorial](/azure/azure-monitor/log-query/log-analytics-tutorial).
 
-All queries in this tutorial use the [Log Analytics demo environment](https://ms.portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/DemoLogsBlade). You can use your own environment, but you might not have some of the tables that are used here. Because the data in the demo environment isn't static, the results of your queries might vary slightly from the results shown here.
+>[!NOTE]
+> Because the data in the demo environment isn't static, the results of your queries might vary slightly from the results shown here.
+
+## Learn common operators 
 
 ## Count rows
 
@@ -684,11 +685,15 @@ SecurityEvent
 
 :::image type="content" source="images/tutorial/azure-monitor-summarize-count-results.png" lightbox="images/tutorial/azure-monitor-summarize-count-results.png" alt-text="Screenshot that shows the results of the summarize count operator example.":::
 
-## Summarize by scalar values
+## Aggregate by scalar values
 
-You can aggregate by scalar values like numbers and time values, but you should use the [bin()](./binfunction.md) function to group rows into distinct sets of data. For example, if you aggregate by `TimeGenerated`, you'll get a row for most time values. Use `bin()` to consolidate values per hour or day.
+When aggregating by scalar values, like numbers and time values, use the [bin()](./binfunction.md) function to group rows into distinct sets of data. 
 
-The [InsightsMetrics](/azure/azure-monitor/reference/tables/insightsmetrics) table contains performance data that's organized according to insights from Azure Monitor for VMs and Azure Monitor for containers. The following query shows the hourly average processor utilization for multiple computers:
+Otherwise, if you aggregate by `TimeGenerated`, you'll get a row for most time values. The `bin()` function consolidates values per hour or day.
+
+The [InsightsMetrics](/azure/azure-monitor/reference/tables/insightsmetrics) table contains performance data that's organized according to insights from Azure Monitor for VMs and Azure Monitor for containers. 
+
+Show the hourly average processor utilization for multiple computers:
 
 ```kusto
 InsightsMetrics
@@ -699,9 +704,9 @@ InsightsMetrics
 
 :::image type="content" source="images/tutorial/azure-monitor-summarize-avg-results.png" lightbox="images/tutorial/azure-monitor-summarize-avg-results.png" alt-text="Screenshot that shows the results of the avg operator example.":::
 
-## Display a chart or table: *render*
+## Visualize time series data
 
-The [render](./renderoperator.md?pivots=azuremonitor) operator specifies how the output of the query is rendered. Log Analytics renders output as a table by default. You can select different chart types after you run the query. The `render` operator is useful to include in queries in which a specific chart type usually is preferred.
+The [render](./renderoperator.md?pivots=azuremonitor) operator specifies how the output of the query is rendered. Log Analytics renders output as a table by default. Select different chart types after you run the query. The `render` operator is useful to include in queries in which a specific chart type usually is preferred.
 
 The following example shows the hourly average processor utilization for a single computer. It renders the output as a timechart.
 
@@ -715,7 +720,7 @@ InsightsMetrics
 
 :::image type="content" source="images/tutorial/azure-monitor-render-results.png" lightbox="images/tutorial/azure-monitor-render-results.png" alt-text="Screenshot that shows the results of the render operator example.":::
 
-## Work with multiple series
+### Multiple series
 
 If you use multiple values in a `summarize by` clause, the chart displays a separate series for each set of values:
 
@@ -731,7 +736,7 @@ InsightsMetrics
 
 ## Join data from two tables
 
-What if you need to retrieve data from two tables in a single query? You can use the [join](./joinoperator.md?pivots=azuremonitor) operator to combine rows from multiple tables in a single result set. Each table must have a column that has a matching value so that the join understands which rows to match.
+To combine rows from multiple tables in a single result set, use the [join](./joinoperator.md?pivots=azuremonitor) operator. Each table must have a column that has a matching value so that the join understands which rows to match.
 
 [VMComputer](/azure/azure-monitor/reference/tables/vmcomputer) is a table that Azure Monitor uses for VMs to store details about virtual machines that it monitors. [InsightsMetrics](/azure/azure-monitor/reference/tables/insightsmetrics) contains performance data that's collected from those virtual machines. One value collected in *InsightsMetrics* is available memory, but not the percentage memory that's available. To calculate the percentage, we need the physical memory for each virtual machine. That value is in `VMComputer`.
 
@@ -750,9 +755,11 @@ VMComputer
 
 :::image type="content" source="images/tutorial/azure-monitor-join-results.png" lightbox="images/tutorial/azure-monitor-join-results.png" alt-text="Screenshot that shows the results of the join operator example.":::
 
-## Assign a result to a variable: *let*
+## Assign a result to a variable
 
-Use [let](./letstatement.md) to make queries easier to read and manage. You can use this operator to assign the results of a query to a variable that you can use later. By using the `let` statement, the query in the preceding example can be rewritten as:
+Use [let](./letstatement.md) to make queries easier to read and manage. The [let](./letstatement.md) statement assigns the results of a query to a variable that can be used later. 
+
+Let's rewrite the query in the preceding example with [let](./letstatement.md):
 
 ```kusto
 let PhysicalComputer = VMComputer


### PR DESCRIPTION
## Structural changes

- Reduced the number of h2 headings
- Created subheadings for each operator
- Rearranged order of some sections (i.e.: I felt the `where` query example should come after the `project`/`take` example since the `where` example uses `project`). 

## Stylistic changes

- Edited the introductions
- Renamed headings
- Removed weak language (i.e.: "you can" / "we could")
- Simplified sentences 
- Modified notes/tips

## Corrections

- Reordered results of `top` query to match real result as returned in the Azure Data Explorer (commit: 4b5a01a35fadec2193ef224f7579c177645f758f)
- Replaced "Azure Data Explorer Query Language" with "Kusto Query Language" in the Azure Monitor tutorial version. NOTE: I'm not sure that was an error. I assumed so, since the tutorial is called "Use Kusto queries". (commit: 842ab790177ae7a1f0ab7af89c1e78f635dd907d)