### PR TITLE
Fix links

### DIFF
--- a/data-explorer/ingest-data-telegraf.md
+++ b/data-explorer/ingest-data-telegraf.md
@@ -62,7 +62,7 @@ To configure authentication for the plugin, set the appropriate environment vari
     * `AZURE_USERNAME`: The username, also known as upn, of an Azure Active Directory user account.
     * `AZURE_PASSWORD`: The password of the Azure Active Directory user account. Note this doesn't support accounts with MFA enabled.
 
-* **Azure Managed Service Identity**: Delegate credential management to the platform. This method requires that code is run in Azure, for example, VM. All configuration is handled by Azure. For more information, see [Azure Managed Service Identity][/azure/active-directory/msi-overview]. This method is only available when using [Azure Resource Manager][/azure/azure-resource-manager/resource-group-overview].
+* **Azure Managed Service Identity**: Delegate credential management to the platform. This method requires that code is run in Azure, for example, VM. All configuration is handled by Azure. For more information, see [Azure Managed Service Identity](/azure/active-directory/msi-overview). This method is only available when using [Azure Resource Manager](/azure/azure-resource-manager/resource-group-overview).
 
 ## Configure Telegraf
 


### PR DESCRIPTION
Fix typo in links, meaning the place they should have redirected to was shown in plain text and not a link.