### PR TITLE
Update dcount-aggfunction.md

### DIFF
--- a/data-explorer/kusto/query/dcount-aggfunction.md
+++ b/data-explorer/kusto/query/dcount-aggfunction.md
@@ -10,7 +10,7 @@ ms.date: 07/10/2022
 Calculates an estimate of the number of distinct values that are taken by a scalar expression in the summary group.
 
 > [!NOTE]
-> The `dcount()` aggregation function is primarily useful for estimating the cardinality of huge sets. It trades performance for accuracy, and may return a result that varies between executions. The order of inputs may have an effect on its output.
+> The `dcount()` aggregation function is primarily useful for estimating the cardinality of huge sets. It trades accuracy for performance, and may return a result that varies between executions. The order of inputs may have an effect on its output.
 
 [!INCLUDE [data-explorer-agg-function-summarize-note](../../includes/data-explorer-agg-function-summarize-note.md)]
 


### PR DESCRIPTION
A function trading performance for accuracy indicates that you are giving up performance in exchange for accuracy.  This is not the case here, as the function is giving up accuracy for better performance