### PR TITLE
Fix mistake in function parse_ipv6() parse-ipv6function.md

### DIFF
--- a/data-explorer/kusto/query/parse-ipv6function.md
+++ b/data-explorer/kusto/query/parse-ipv6function.md
@@ -30,7 +30,7 @@ The IP address to the LEFT of the slash (`/`) is the base IP address. The number
 ## Returns
 
 If conversion is successful, the result will be a string representing a canonical IPv6 network address.
-If conversion isn't successful, the result will be `null`.
+If conversion isn't successful, the result will be an empty string.
 
 ## Example
 


### PR DESCRIPTION
Currently, it does not return a null, like parse_ipv4 does.

I think Azure Data Explorer developers should fix that.

![image](https://user-images.githubusercontent.com/2527990/194312309-792cbab8-a673-480d-a3e3-3f723404cb6d.png)

