### PR TITLE
Typo fix: arrayifffunction.md

### DIFF
--- a/data-explorer/kusto/query/arrayifffunction.md
+++ b/data-explorer/kusto/query/arrayifffunction.md
@@ -13,7 +13,7 @@ Another alias: array_iff().
 
 ## Syntax
 
-`array_iif(`*ConditionArray*, *IfTrue*, *IfFalse*]`)`
+`array_iif(`*ConditionArray*, *IfTrue*, *IfFalse*`)`
 
 ## Arguments
 


### PR DESCRIPTION
Looks like the ']' doesn't belong there as those are all required parameters