### PR TITLE
Summarize operator docs: Fix default aggregate values example

### DIFF
--- a/data-explorer/kusto/query/summarizeoperator.md
+++ b/data-explorer/kusto/query/summarizeoperator.md
@@ -155,9 +155,9 @@ datatable(x:long)[]
 | summarize any(x), arg_max(x, x), arg_min(x, x), avg(x), buildschema(todynamic(tostring(x))), max(x), min(x), percentile(x, 55), hll(x) ,stdev(x), sum(x), sumif(x, x > 0), tdigest(x), variance(x)
 ```
 
-|any_x|max_x|max_x_x|min_x|min_x_x|avg_x|schema_x|max_x1|min_x1|percentile_x_55|hll_x|stdev_x|sum_x|sumif_x|tdigest_x|variance_x|
+|any_x|x|x1|x2|x3|avg_x|schema_x|max_x|min_x|percentile_x_55|hll_x|stdev_x|sum_x|sumif_x|tdigest_x|variance_x|
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-|||||||||||||||||
+||||||NaN||||||0|0|0||0|
 
 ```kusto
 datatable(x:long)[]

--- a/data-explorer/kusto/query/summarizeoperator.md
+++ b/data-explorer/kusto/query/summarizeoperator.md
@@ -152,10 +152,10 @@ When the input of `summarize` operator doesn't have an empty group-by key, the r
 
 ```kusto
 datatable(x:long)[]
-| summarize any(x), arg_max(x, x), arg_min(x, x), avg(x), buildschema(todynamic(tostring(x))), max(x), min(x), percentile(x, 55), hll(x) ,stdev(x), sum(x), sumif(x, x > 0), tdigest(x), variance(x)
+| summarize any(x), arg_max=arg_max(x, x), arg_min=arg_min(x, x), avg(x), buildschema(todynamic(tostring(x))), max(x), min(x), percentile(x, 55), hll(x) ,stdev(x), sum(x), sumif(x, x > 0), tdigest(x), variance(x)
 ```
 
-|any_x|x|x1|x2|x3|avg_x|schema_x|max_x|min_x|percentile_x_55|hll_x|stdev_x|sum_x|sumif_x|tdigest_x|variance_x|
+|any_x|arg_max|x|arg_min|x1|avg_x|schema_x|max_x|min_x|percentile_x_55|hll_x|stdev_x|sum_x|sumif_x|tdigest_x|variance_x|
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 ||||||NaN||||||0|0|0||0|
 


### PR DESCRIPTION
This change fixes the example for the default values of the aggregate functions in the summarize operator documentation.

- Some of the default values documented did not match the actual result when executing the query in dataexplorer.azure.com . This has been updated to match the actual result.
- When updating this example, the name of the columns in the resulting table are not clear. To improve clarity, names have been added to two columns which produced ambiguous column names ("x", "x1", "x2", "x3").
  - There still exist columns "x" and "x2", produced from the min and max aggregation functions. I don't know how to rename these columns, I'd like to make them match the original documentation

The original reason I looked at this file was because I couldn't tell what the values were in the documentation. The contents of the table are unreadable, but it wasn't clear that it was expected that nothing was expected to be there.

![image](https://user-images.githubusercontent.com/16418643/200446585-f035f379-0ff7-4408-943c-85109cef1a42.png)
