### PR TITLE
Fixed the typo in alter table command

### DIFF
--- a/data-explorer/kusto/management/alter-table-command.md
+++ b/data-explorer/kusto/management/alter-table-command.md
@@ -31,7 +31,7 @@ The `.alter table` command:
  * When you alter a table, altering a column type isn't supported. Use the [`.alter column`](alter-column.md) command instead.
 
 > [!TIP]
-> Use `.show table [TableName] cslschema` to get the existing column schema before you alter it.
+> Use `.show table [TableName] cslschema` to get the existing table schema before you alter it.
 
 
 How will the command affect the data?


### PR DESCRIPTION
The given command shows the schema of a table and not a column.