### PR TITLE
add description about data size that external table can handle

### DIFF
--- a/data-explorer/kusto/query/schema-entities/externaltables.md
+++ b/data-explorer/kusto/query/schema-entities/externaltables.md
@@ -41,3 +41,4 @@ For more information about how to query external tables, and ingested and uninge
 * Maximum limit of external tables per database is 1,000.
 * Kusto supports [export](../../management/data-export/export-data-to-an-external-table.md) and [continuous export](../../management/data-export/continuous-data-export.md) to an external table.
 * [Data purge](../../concepts/data-purge.md) isn't applied on external tables. Records are never deleted from external tables.
+* External table is recommended for data that is less than 1 GB 


### PR DESCRIPTION
Hello, could you add a description about data size that external table can effectively handle? I heard that users cannot receive the benefit of sharding and indexing when they use external tables. Some of users consider external tables as a way of cost saving, but in most cases it does not work because the data size can be handled is small.
I hope you would take this into account.

Thank you.