### PR TITLE
note `serialize` does not sort.

### DIFF
--- a/data-explorer/kusto/query/serializeoperator.md
+++ b/data-explorer/kusto/query/serializeoperator.md
@@ -9,7 +9,7 @@ ms.date: 01/22/2023
 
 Marks that the order of the input row set is safe to use for window functions.
 
-The operator has a declarative meaning. It marks the input row set as serialized (ordered), so that [window functions](./windowsfunctions.md) can be applied to it.
+The operator has a declarative meaning. It marks the input row set as serialized (ordered), so that [window functions](./windowsfunctions.md) can be applied to it. It does not sort the input row set. 
 
 ```kusto
 T | serialize rn=row_number()
@@ -19,7 +19,7 @@ T | serialize rn=row_number()
 
 `serialize` [*Name1* `=` *Expr1* [`,` *Name2* `=` *Expr2*]...]
 
-* The *Name*/*Expr* pairs are similar to those pairs in the [extend operator](./extendoperator.md).
+* The *Name*/*Expr* pairs are similar to those pairs in the [extend operator](./extendoperator.md). Following the same behaviour, an un-aliased expression will be  automatically named and a bare column will make no change to the output row set. 
 
 ## Example
 


### PR DESCRIPTION
The docs page does not explicitly state that no sorting occurs from the `serialize` operator. 

More verbose description of "_similar to `extends`_" behavior in the `[*Name2* = *Expr2*]` syntax notes.

This follows from some confusion on my end implementing the operator. In the below example, I had previously assumed that `serialize b, a` would be the same as `sort by b ,a`

```kusto
datatable(
    a: int, 
    b: int,
    c: int
)[
    7,8,9,
    1,2,3,
    4,5,6,
]
| serialize b, a
```