### PR TITLE
Add missing comma in the syntax of `.create-or-alter function`

### DIFF
--- a/data-explorer/kusto/management/create-alter-function.md
+++ b/data-explorer/kusto/management/create-alter-function.md
@@ -13,7 +13,7 @@ Rules for parameter types and CSL statements are the same as for [`let` statemen
 
 ## Syntax
 
-.`create-or-alter function [with (docstring = '<description>' folder='<name>')] [FunctionName] ([paramName:paramType], ...) { CSL-statement }`
+.`create-or-alter function [with (docstring = '<description>', folder='<name>')] [FunctionName] ([paramName:paramType], ...) { CSL-statement }`
 
 If the function with the provided *FunctionName* doesn't exist in the database metadata, the command creates a new function. Else, that function will be changed.
 


### PR DESCRIPTION
Add missing comma in the syntax of `.create-or-alter function`