### PR TITLE
Update drop-external-table.md

### DIFF
--- a/data-explorer/kusto/management/drop-external-table.md
+++ b/data-explorer/kusto/management/drop-external-table.md
@@ -31,6 +31,6 @@ Returns the properties of the dropped external table. For more information, see 
 .drop external table ExternalBlob
 ```
 
-| TableName | TableType | Folder         | DocString | Schema       | Properties |
-|-----------|-----------|----------------|-----------|-----------------------------------------------------|------------|
-| T         | Blob      | ExternalTables | Docs      | [{ "Name": "x",  "CslType": "long"},<br> { "Name": "s",  "CslType": "string" }] | {}         |
+| TableName   | TableType | Folder         | DocString | Properties | ConnectionStrings | Partitions | PathFormat |
+|-------------|-----------|----------------|-----------|------------|-------------------|------------|------------|
+| ExternalBlob|           |                |           |            |                   |            |            |


### PR DESCRIPTION
This is what V3 returns as the output for the following .drop external table, having executed the following .create external table previously:

.create external table ExternalBlob (s:string, x:long)   kind=storage 
dataformat=parquet 
( 
   h@'https://storageialonso.blob.core.windows.net/table;storageKey1' 
)
with (docString = "Docs", folder = "ExternalTables")

.drop external table ExternalBlob