### PR TITLE
Remove duplicate example in materialized_view function article

### DIFF
--- a/data-explorer/kusto/query/materialized-view-function.md
+++ b/data-explorer/kusto/query/materialized-view-function.md
@@ -44,4 +44,4 @@ materialized_view("ViewName", 10m)
 * Once a view is created, it can be queried just as any other table in the database, including participate in cross-cluster / cross-database queries.
 * Materialized views aren't included in wildcard unions or searches.
 * Syntax for querying the view is the view name (like a table reference).
-* Querying the materialized view will always return the most up-to-date results, based on all records ingested to the source table. The query combines the materialized part of the view with all unmaterialized records in the source table. For more information, see [behind the scenes](../management/materialized-views/materialized-view-overview.md#how-materialized-views-work) for details.
+* Querying the materialized view will always return the most up-to-date results, based on all records ingested to the source table. The query combines the materialized part of the view with all unmaterialized records in the source table. For more information, see [how materialized views work](../management/materialized-views/materialized-view-overview.md#how-materialized-views-work) for details.

--- a/data-explorer/kusto/query/materialized-view-function.md
+++ b/data-explorer/kusto/query/materialized-view-function.md
@@ -12,11 +12,6 @@ References the materialized part of a [materialized view](../management/material
 
 The `materialized_view()` function supports a way of querying the *materialized* part only of the view, while specifying the max latency the user is willing to tolerate. This option isn't guaranteed to return the most up-to-date records, but should always be more performant than querying the entire view. This function is useful for scenarios in which you're willing to sacrifice some freshness for performance, for example in telemetry dashboards.
 
-<!--- csl --->
-```kusto
-materialized_view('ViewName')
-```
-
 ## Syntax
 
 `materialized_view(`*ViewName*`,` [ *max_age* ] `)`


### PR DESCRIPTION
The example removed belongs to the **Examples** section and it was already in there.