### PR TITLE
Add few clarifications about the functioning of json mapping

### DIFF
--- a/data-explorer/kusto/management/json-mapping.md
+++ b/data-explorer/kusto/management/json-mapping.md
@@ -16,6 +16,7 @@ Each JSON mapping element may contain the following optional `properties`:
 |Property|Description|
 |--|--|
 |`Path`|If the value starts with `$`: JSON path to the field that will become the content of the column in the JSON document. The JSON path that denotes the entire document is `$`. If the value doesn't start with `$`: the value is interpreted as a constant which is set in the column, as long as the column's data type supports such value. If it doesn't, then that column is set to null. JSON paths that include special characters should be escaped as [\'Property Name\']. For more information, see [JSONPath syntax](../query/jsonpath.md).|
+|`ConstValue`|The constant value to be used for a column instead of some value inside the JSON file.|
 |`Transform`|Transformation that should be applied on the content with [mapping transformations](mappings.md#mapping-transformations).|
 
 [!INCLUDE [data-mapping-type-note](../../includes/data-mapping-type-note.md)]

--- a/data-explorer/kusto/management/json-mapping.md
+++ b/data-explorer/kusto/management/json-mapping.md
@@ -15,8 +15,7 @@ Each JSON mapping element may contain the following optional `properties`:
 
 |Property|Description|
 |--|--|
-|`Path`|If the value starts with `$`: JSON path to the field that will become the content of the column in the JSON document. The JSON path that denotes the entire document is `$`. If the value doesn't start with `$`: a constant value is used. JSON paths that include special characters should be escaped as [\'Property Name\']. For more information, see [JSONPath syntax](../query/jsonpath.md).|
-|`ConstantValue`|The constant value to be used for a column instead of some value inside the JSON file.|
+|`Path`|If the value starts with `$`: JSON path to the field that will become the content of the column in the JSON document. The JSON path that denotes the entire document is `$`. If the value doesn't start with `$`: the value is interpreted as a constant which is set in the column, as long as the column's data type supports such value. If it doesn't, then that column is set to null. JSON paths that include special characters should be escaped as [\'Property Name\']. For more information, see [JSONPath syntax](../query/jsonpath.md).|
 |`Transform`|Transformation that should be applied on the content with [mapping transformations](mappings.md#mapping-transformations).|
 
 [!INCLUDE [data-mapping-type-note](../../includes/data-mapping-type-note.md)]


### PR DESCRIPTION
My tests reveal that ConstantValue property is not honored. A null is always inserted in place of the constant provided. Either this functionality is obsolete or there is some defect in the code which should be reviewed and fixed. If that is not expected to work, remove any mention to that property. If it has been deprecated and currently has no effect, some important notice should be added.