### PR TITLE
Add information in sliding-window-counts-plugin.md

### DIFF
--- a/data-explorer/kusto/query/sliding-window-counts-plugin.md
+++ b/data-explorer/kusto/query/sliding-window-counts-plugin.md
@@ -22,7 +22,7 @@ Calculates counts and distinct count of values in a sliding window over a lookba
 | *TimelineColumn* | string | &check; | The name of the column representing the timeline.|
 | *Start* | int, long, real, datetime, or timespan | &check; | The analysis start period.|
 | *End* | int, long, real, datetime, or timespan | &check; | The analysis end period.|
-| *LookbackWindow* | int, long, real, datetime, or timespan | &check; | The lookback period. For example, for `dcount` users in past `7d`: *LookbackWindow* = `7d`.|
+| *LookbackWindow* | int, long, real, datetime, or timespan | &check; | The lookback period, this value must be a multiple of *Bin*, if not the *LookbackWindow* value will be replaced by the *Bin* value. For example, for `dcount` users in past `7d`: *LookbackWindow* = `7d`.|
 | *Bin* | int, long, real, datetime, timespan, or string | &check; | The analysis step period. The possible string values are `week`, `month`, and `year` for which all periods will be [startofweek](startofweekfunction.md), [startofmonth](startofmonthfunction.md), [startofyear](startofyearfunction.md) respectively. |
 | *dim1*, *dim2*, ... | string | | A list of the dimensions columns that slice the activity metrics calculation.|
 

--- a/data-explorer/kusto/query/sliding-window-counts-plugin.md
+++ b/data-explorer/kusto/query/sliding-window-counts-plugin.md
@@ -22,7 +22,7 @@ Calculates counts and distinct count of values in a sliding window over a lookba
 | *TimelineColumn* | string | &check; | The name of the column representing the timeline.|
 | *Start* | int, long, real, datetime, or timespan | &check; | The analysis start period.|
 | *End* | int, long, real, datetime, or timespan | &check; | The analysis end period.|
-| *LookbackWindow* | int, long, real, datetime, or timespan | &check; | The lookback period, this value must be a multiple of *Bin*, if not the *LookbackWindow* value will be replaced by the *Bin* value. For example, for `dcount` users in past `7d`: *LookbackWindow* = `7d`.|
+| *LookbackWindow* | int, long, real, datetime, or timespan | &check; | The lookback period, this value should be a multiple of the *Bin* value, if not the *LookbackWindow* value will be replaced by a multiple of the *Bin* value. For example, for `dcount` users in past `7d`: *LookbackWindow* = `7d`.|
 | *Bin* | int, long, real, datetime, timespan, or string | &check; | The analysis step period. The possible string values are `week`, `month`, and `year` for which all periods will be [startofweek](startofweekfunction.md), [startofmonth](startofmonthfunction.md), [startofyear](startofyearfunction.md) respectively. |
 | *dim1*, *dim2*, ... | string | | A list of the dimensions columns that slice the activity metrics calculation.|
 

--- a/data-explorer/kusto/query/sliding-window-counts-plugin.md
+++ b/data-explorer/kusto/query/sliding-window-counts-plugin.md
@@ -22,7 +22,7 @@ Calculates counts and distinct count of values in a sliding window over a lookba
 | *TimelineColumn* | string | &check; | The name of the column representing the timeline.|
 | *Start* | int, long, real, datetime, or timespan | &check; | The analysis start period.|
 | *End* | int, long, real, datetime, or timespan | &check; | The analysis end period.|
-| *LookbackWindow* | int, long, real, datetime, or timespan | &check; | The lookback period, this value should be a multiple of the *Bin* value, if not the *LookbackWindow* value will be replaced by a multiple of the *Bin* value. For example, for `dcount` users in past `7d`: *LookbackWindow* = `7d`.|
+| *LookbackWindow* | int, long, real, datetime, or timespan | &check; | The lookback period. This value should be a multiple of the *Bin* value, otherwise the *LookbackWindow* will be rounded down to a multiple of the *Bin* value. For example, for `dcount` users in past `7d`: *LookbackWindow* = `7d`.|
 | *Bin* | int, long, real, datetime, timespan, or string | &check; | The analysis step period. The possible string values are `week`, `month`, and `year` for which all periods will be [startofweek](startofweekfunction.md), [startofmonth](startofmonthfunction.md), [startofyear](startofyearfunction.md) respectively. |
 | *dim1*, *dim2*, ... | string | | A list of the dimensions columns that slice the activity metrics calculation.|
 


### PR DESCRIPTION
Making some tests, the effective LookbackWindow is not always the parameter specified in the function:

Example:

LookbackWindow is 30m and Bin is 50m - effective LookbackWindow is 50m
LookbackWindow is 40m and Bin is 50m - effective LookbackWindow is 50m

LookbackWindow is 50m and Bin is 50m - effective LookbackWindow is 50m
LookbackWindow is 60m and Bin is 50m - effective LookbackWindow is 50m
LookbackWindow is 70m and Bin is 50m - effective LookbackWindow is 50m
LookbackWindow is 80m and Bin is 50m - effective LookbackWindow is 50m
LookbackWindow is 90m and Bin is 50m - effective LookbackWindow is 50m

LookbackWindow is 100m and Bin is 50m - effective LookbackWindow is 100m
LookbackWindow is 110m and Bin is 50m - effective LookbackWindow is 100m
...

Maybe this preference of the LookbackWindow value should be explained in the sliding_window_counts plugin description.

