### PR TITLE
Note one-way for private endpoints

### DIFF
--- a/data-explorer/security-network-managed-private-endpoint-create.md
+++ b/data-explorer/security-network-managed-private-endpoint-create.md
@@ -8,7 +8,7 @@ ms.date: 04/05/2022
 
 # Create a managed private endpoint for Azure Data Explorer
 
-Managed private endpoints are required to connect to Azure resources that are highly protected. In this article, you'll learn how to create a managed private endpoint and connect it to your data source.
+Managed private endpoints are required to connect to Azure resources that are highly protected. They are one-way private connections for data flowing from Azure Data Explorer to other protected services. In this article, you'll learn how to create a managed private endpoint and connect it to your data source.
 
 ## Prerequisites
 


### PR DESCRIPTION
I write for [Azure Digital Twins](https://learn.microsoft.com/azure/digital-twins/). Some Azure Digital Twins customers have apparently thought that setting up a managed private endpoint from ADX to ADT would allow data to also flow the other way, from ADT to ADX. One of the ADT developers has suggested this is not the case and that it might be good to clarify it in the ADX docs for this feature.