### PR TITLE
Add lookup suggestion to Kusto best practices.

### DIFF
--- a/data-explorer/kusto/query/best-practices.md
+++ b/data-explorer/kusto/query/best-practices.md
@@ -32,6 +32,7 @@ Here are several best practices to follow to make your query run faster.
 |  | Use `in` instead of left semi `join` for filtering by a single column. |  |
 | Join across clusters | Across clusters, run the query on the "right" side of the join, where most of the data is located. |  |
 | Join when left side is small and right side is large | Use [hint.strategy=broadcast](./broadcastjoin.md) |  | Small refers to up to 100,000 records. |
+| Join when right side is small and left side is large | Consider using [lookup operator](./lookupoperator.md) instead of `join` operator |  | Small refers to serveral tens of MBs. |
 | Join when both sides are too large | Use [hint.shufflekey=\<key>](./shufflequery.md) |  | Use when the join key has high cardinality. |
 | **Extract values on column with strings sharing the same format or pattern** | Use the [parse operator](./parseoperator.md) | Don't use several `extract()` statements. | For example, values like `"Time = <time>, ResourceId = <resourceId>, Duration = <duration>, ...."` |
 | **[extract() function](./extractfunction.md)** | Use when parsed strings don't all follow the same format or pattern. |  | Extract the required values by using a REGEX. |

--- a/data-explorer/kusto/query/best-practices.md
+++ b/data-explorer/kusto/query/best-practices.md
@@ -32,7 +32,7 @@ Here are several best practices to follow to make your query run faster.
 |  | Use `in` instead of left semi `join` for filtering by a single column. |  |
 | Join across clusters | Across clusters, run the query on the "right" side of the join, where most of the data is located. |  |
 | Join when left side is small and right side is large | Use [hint.strategy=broadcast](./broadcastjoin.md) |  | Small refers to up to 100,000 records. |
-| Join when right side is small and left side is large | Consider using [lookup operator](./lookupoperator.md) instead of `join` operator |  | Small refers to serveral tens of MBs. |
+| Join when right side is small and left side is large | Use the [lookup operator](./lookupoperator.md) instead of the `join` operator | | If the right side of the lookup is larger than several tens of MBs, the query will fail. |
 | Join when both sides are too large | Use [hint.shufflekey=\<key>](./shufflequery.md) |  | Use when the join key has high cardinality. |
 | **Extract values on column with strings sharing the same format or pattern** | Use the [parse operator](./parseoperator.md) | Don't use several `extract()` statements. | For example, values like `"Time = <time>, ResourceId = <resourceId>, Duration = <duration>, ...."` |
 | **[extract() function](./extractfunction.md)** | Use when parsed strings don't all follow the same format or pattern. |  | Extract the required values by using a REGEX. |


### PR DESCRIPTION
As written in this documentation: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/lookupoperator
> In terms of performance, the system by default assumes that the $left table is the larger (facts) table, and the $right table is the smaller (dimensions) table. **This is exactly opposite to the assumption used by the join operator.**

`lookup` is much faster than `join` when left table is much large than right table.