### PR TITLE
Added missing limitation for RLS

### DIFF
--- a/data-explorer/kusto/management/rowlevelsecuritypolicy.md
+++ b/data-explorer/kusto/management/rowlevelsecuritypolicy.md
@@ -37,7 +37,7 @@ There's no limit on the number of tables on which Row Level Security policy can 
 
 The RLS policy can't be enabled on a table:
 
-* referenced by a query of an [update policy](./updatepolicy.md).
+* referenced by a query of an [update policy](./updatepolicy.md) or [continuous data export](../data-export/continuous-data-export.md).
 * on which [restricted view access policy](./restrictedviewaccesspolicy.md) is configured.
 
 ## Examples

--- a/data-explorer/kusto/management/rowlevelsecuritypolicy.md
+++ b/data-explorer/kusto/management/rowlevelsecuritypolicy.md
@@ -37,7 +37,7 @@ There's no limit on the number of tables on which Row Level Security policy can 
 
 The RLS policy can't be enabled on a table:
 
-* referenced by a query of an [update policy](./updatepolicy.md) or [continuous data export](./../data-export/continuous-data-export.md).
+* referenced by a query of an [update policy](./updatepolicy.md) or [continuous data export](../management/data-export/continuous-data-export.md).
 * on which [restricted view access policy](./restrictedviewaccesspolicy.md) is configured.
 
 ## Examples

--- a/data-explorer/kusto/management/rowlevelsecuritypolicy.md
+++ b/data-explorer/kusto/management/rowlevelsecuritypolicy.md
@@ -37,7 +37,7 @@ There's no limit on the number of tables on which Row Level Security policy can 
 
 The RLS policy can't be enabled on a table:
 
-* referenced by a query of an [update policy](./updatepolicy.md) or [continuous data export](../data-export/continuous-data-export.md).
+* referenced by a query of an [update policy](./updatepolicy.md) or [continuous data export](./../data-export/continuous-data-export.md).
 * on which [restricted view access policy](./restrictedviewaccesspolicy.md) is configured.
 
 ## Examples


### PR DESCRIPTION
In the limitations section of the RLS article the information was missing that RLS is not working when the table is referenced in a continuous export