### PR TITLE
Update join-rightouter.md to point back to left instead of itself

### DIFF
--- a/data-explorer/kusto/query/join-rightouter.md
+++ b/data-explorer/kusto/query/join-rightouter.md
@@ -8,7 +8,7 @@ ms.date: 06/18/2023
 
 # rightouter join
 
-The `rightouter` join flavor returns all the records from the right side and only matching records from the left side. This join flavor resembles the [`rightouter` join flavor](join-rightouter.md), but the treatment of the tables is reversed.
+The `rightouter` join flavor returns all the records from the right side and only matching records from the left side. This join flavor resembles the [`leftouter` join flavor](join-leftouter.md), but the treatment of the tables is reversed.
 
 ## Syntax
 


### PR DESCRIPTION
Noticed a reference pointing back to itself, which makes sense based on this file's history where it started as a clone from left and slowly morphed into right 😁  This is a quick update to point that reference back to left.