### PR TITLE
Update security role overview with more links

### DIFF
--- a/data-explorer/kusto/management/security-roles.md
+++ b/data-explorer/kusto/management/security-roles.md
@@ -105,12 +105,12 @@ To see the roles assigned to all principals for a particular resource, run the f
 .show materialized-view MaterializedViewName principals
 ```
 
+> [!TIP]
+> Use the [where](../query/where-operator.md) operator to filter the results by a specific principal or role.
+
 ### Modify the role assignments
 
 For details on how to modify your role assignments at the database and table levels, see [Manage database security roles](manage-database-security-roles.md) and [Manage table security roles](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/manage-table-security-roles.md).
-
-> [!TIP]
-> Use the [where](../query/where-operator.md) operator to filter the results by a specific principal or role.
 
 ## Related content
 

--- a/data-explorer/kusto/management/security-roles.md
+++ b/data-explorer/kusto/management/security-roles.md
@@ -105,6 +105,10 @@ To see the roles assigned to all principals for a particular resource, run the f
 .show materialized-view MaterializedViewName principals
 ```
 
+### Modify the role assignments
+
+For details on how to modify your role assignments at the database and table levels, see [Manage database security roles](manage-database-security-roles.md) and [Manage table security roles](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/manage-table-security-roles.md).
+
 > [!TIP]
 > Use the [where](../query/where-operator.md) operator to filter the results by a specific principal or role.
 

--- a/data-explorer/kusto/management/security-roles.md
+++ b/data-explorer/kusto/management/security-roles.md
@@ -110,7 +110,7 @@ To see the roles assigned to all principals for a particular resource, run the f
 
 ### Modify the role assignments
 
-For details on how to modify your role assignments at the database and table levels, see [Manage database security roles](manage-database-security-roles.md) and [Manage table security roles](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/manage-table-security-roles.md).
+For details on how to modify your role assignments at the database and table levels, see [Manage database security roles](manage-database-security-roles.md) and [Manage table security roles](manage-table-security-roles.md).
 
 ## Related content
 


### PR DESCRIPTION
Modifying security roles is among common scenarios of security roles. However, the ["Common scenarios" paragraph in article "Security roles overview"](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/security-roles#common-scenarios) focuses only on how to "show" the roles and lacks information on how to modify them. As there are two other articles to discuss that in more details, I updated the "Common scenarios" paragraph by adding a sub-paragraph called "Modify the role assignments" and in this paragraph add links to
* Manage database security roles
* Manage table security roles