### PR TITLE
Update tutorial-archive.md

### DIFF
--- a/data-explorer/kusto/query/tutorial-archive.md
+++ b/data-explorer/kusto/query/tutorial-archive.md
@@ -1,69 +1,66 @@
 ---
-title: 'Tutorial: Kusto queries archive'
+title: 'Tutorial: Kusto Query Language query overview'
 description: This archive tutorial describes how to use queries in the Kusto Query Language to meet common query needs.
 ms.reviewer: alexans
 ms.topic: reference
 ms.date: 11/01/2021
 ---
 
-# Tutorial: Use Kusto queries archive
+# Tutorial: Kusto Query Language query overview
 
-The best way to learn about the Kusto Query Language is to look at some basic queries to get a "feel" for the language. We recommend using a [database with some sample data](https://help.kusto.windows.net/Samples). The queries that are demonstrated in this tutorial should run on that database. The `StormEvents` table in the sample database provides some information about storms that happened in the United States.
+Kusto Query Language (KQL) is used to write queries in Azure Data Explorer, Azure Monitor Log Analytics, Azure Sentinel, and more. A query consists of a data source (usually a table name), followed by a function, also known as an operator. This tutorial is an introduction to the common KQL operators used to access, analyze and view your data.
 
-## Count rows
+The best way to learn about the KQL is to look at some basic queries to get a sense of the language. In this tutorial we will be using data from the [StormEvents table](https://help.kusto.windows.net/Samples) . The `StormEvents` table in the samples database provides some information about storm events that have taken place in the United States.
 
-Our example database has a table called `StormEvents`. We want to find out how large the table is. So we'll pipe its content into an operator that counts the rows in the table.
+In this tutorial, you'll learn how to:
 
-*Syntax note*: A query is a data source (usually a table name), optionally followed by one or more pairs of the pipe character and some tabular operator.
+1. [Count rows](#count-rows-count)
+2. [Show *n* rows](#show-n-rows-take)
+3. [Select a subset of columns](#select-a-subset-of-columns-project)
+4. [Filter by condition](#filter-by-condition-where)
+5. [Order results](#order-results-top-sort)
+6. [Create computed columns](#create-computed-columns-extend)
+7. [Aggregate groups of rows](#aggregate-groups-of-rows-summarize)
+8. [Summarize by scalar values](#summarize-by-scalar-values-bin)
+9. [Display a chart](#display-a-chart-render)
+10. [Display timecharts](#display-timecharts)
+11. [Aggregate multiple series](#aggregate-multiple-series)
+12. [Plot a distribution](#plot-a-distribution)
+13. [Join data type](#join-data-types-join)
+14. [Calculate percentiles](#calculate-percentiles-percentile)
+15. [Calculate percentages](#calculate-percentages-percentage)
+16. [Assign a result to a variable](#assign-a-result-to-a-variable-let)
+17. [Combine data from multiple tables](#combine-data-from-multiple-tables-join)
+18. [Combine data from multiple databases](#combine-data-from-multiple-databases-union)
+
+
+## Count rows: *count*
+
+In order to find out how many records there are in the `StormEvents` table, we will use the [count](../count-operator.md) operator.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
 StormEvents | count
 ```
 
-Here's the output:
+Output:
 
 |Count|
 |-----|
 |59066|
 
-For more information, see [count operator](./count-operator.md).
-
-## Select a subset of columns: *project*
-
-Use [project](./project-operator.md) to pick out only the columns you want. See the following example, which uses both the [project](./project-operator.md)
-and the [take](./take-operator.md) operators.
-
-## Filter by Boolean expression: *where*
-
-Let's see only `flood` events in `California` in Feb-2007:
-
-<!-- csl: https://help.kusto.windows.net/Samples -->
-```kusto
-StormEvents
-| where StartTime > datetime(2007-02-01) and StartTime < datetime(2007-03-01)
-| where EventType == 'Flood' and State == 'CALIFORNIA'
-| project StartTime, EndTime , State , EventType , EpisodeNarrative
-```
-
-Here's the output:
-
-|StartTime|EndTime|State|EventType|EpisodeNarrative|
-|---|---|---|---|---|
-|2007-02-19 00:00:00.0000000|2007-02-19 08:00:00.0000000|CALIFORNIA|Flood|A frontal system moving across the Southern San Joaquin Valley brought brief periods of heavy rain to western Kern County in the early morning hours of the 19th. Minor flooding was reported across State Highway 166 near Taft.|
 
 ## Show *n* rows: *take*
 
-Let's see some data. What's in a random sample of five rows?
+To limit the number of records returned, use the [take](../take-operator.md) operator. This operator returns a specified number of random rows from the table, to give a general sense of the data it contains.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
 StormEvents
 | take 5
-| project  StartTime, EndTime, EventType, State, EventNarrative  
 ```
 
-Here's the output:
+Output:
 
 |StartTime|EndTime|EventType|State|EventNarrative|
 |---|---|---|---|---|
@@ -73,14 +70,44 @@ Here's the output:
 |2007-12-20 07:50:00.0000000|2007-12-20 07:53:00.0000000|Thunderstorm Wind|MISSISSIPPI|Numerous large trees were blown down with some down on power lines. Damage occurred in eastern Adams county.|
 |2007-12-30 16:00:00.0000000|2007-12-30 16:05:00.0000000|Thunderstorm Wind|GEORGIA|The county dispatch reported several trees were blown down along Quincey Batten Loop near State Road 206. The cost of tree removal was estimated.|
 
-But [take](./take-operator.md) shows rows from the table in no particular order, so let's sort them. ([limit](./take-operator.md) is an alias for [take](./take-operator.md) and has the same effect.)
+The [limit](./take-operator.md) operator has the same effect as the [take](./take-operator.md) operator.
 
-## Order results: *sort*, *top*
+## Select a subset of columns: *project*
 
-* *Syntax note*: Some operators have parameters that are introduced by keywords like `by`.
-* In the following example, `desc` orders results in descending order and `asc` orders results in ascending order.
+Use `project` to select select specific columns you want to view. The following example uses both the [project](./project-operator.md)
+and the [take](./take-operator.md) operators.
+  
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents
+| take 5
+| project  StartTime, EndTime, EventType, State, EventNarrative  
+```
 
-Show me the first *n* rows, ordered by a specific column:
+## Filter by condition: *where*
+
+The [where](../where-operator.md) operator filters rows of data based on certain criteria. Let's see only floo events, which took place in California in Feb-2007:
+  
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents
+| where StartTime > datetime(2007-02-01) and StartTime < datetime(2007-03-01)
+| where EventType == 'Flood' and State == 'CALIFORNIA'
+| project StartTime, EndTime , State , EventType , EpisodeNarrative
+```  
+
+Output:
+There is only one record which fits these criteria.
+
+|StartTime|EndTime|State|EventType|EpisodeNarrative|
+|---|---|---|---|---|
+|2007-02-19 00:00:00.0000000|2007-02-19 08:00:00.0000000|CALIFORNIA|Flood|A frontal system moving across the Southern San Joaquin Valley brought brief periods of heavy rain to western Kern County in the early morning hours of the 19th. Minor flooding was reported across State Highway 166 near Taft.|
+
+## Order results: *top*, *sort*
+
+The [top](../top-operator.md) or [sort](../sort-operator.md) operators allow you to order the data according to a specified parameter. These operators are introduced by keywords like `by`. In the example, `desc` will order results in descending order. Use `asc` to order results in ascending order.
+
+The [top](../top-operator.md) operator will show the first *n* rows, sorted by a specific column:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -89,7 +116,7 @@ StormEvents
 | project  StartTime, EndTime, EventType, State, EventNarrative  
 ```
 
-Here's the output:
+Output:
 
 |StartTime|EndTime|EventType|State|EventNarrative|
 |---|---|---|---|---|
@@ -99,7 +126,7 @@ Here's the output:
 |2007-12-31 23:53:00.0000000|2007-12-31 23:53:00.0000000|High Wind|CALIFORNIA|North to northeast winds gusting to around 58 mph were reported in the mountains of Ventura county.|
 |2007-12-31 23:53:00.0000000|2007-12-31 23:53:00.0000000|High Wind|CALIFORNIA|The Warm Springs RAWS sensor reported northerly winds gusting to 58 mph.|
 
-You can achieve the same result by using  either [sort](./sort-operator.md), and then [take](./take-operator.md):
+You can also use the [sort](./sort-operator.md) operator, and then the [take](./take-operator.md) operator to see a random set of ordered records.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -109,9 +136,11 @@ StormEvents
 | project  StartTime, EndTime, EventType, EventNarrative
 ```
 
-## Compute derived columns: *extend*
+## Create computed columns: *extend*
 
-Create a new column by computing a value in every row:
+The [extend](../extend-operator.md) operator creates calculated columns. Use `extend` to create an additional column with the calculated values for each row.
+
+The following query creates a `Duration` column, calculated as the difference between the `StartTime` and `EndTime`. Use `project` to stipulate the columns you want to view.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -121,7 +150,7 @@ StormEvents
 | project StartTime, EndTime, Duration, EventType, State
 ```
 
-Here's the output:
+Output:
 
 |StartTime|EndTime|Duration|EventType|State|
 |---|---|---|---|---|
@@ -131,28 +160,13 @@ Here's the output:
 |2007-12-20 07:50:00.0000000|2007-12-20 07:53:00.0000000|00:03:00|Thunderstorm Wind|MISSISSIPPI|
 |2007-12-30 16:00:00.0000000|2007-12-30 16:05:00.0000000|00:05:00|Thunderstorm Wind|GEORGIA|
 
-It's possible to reuse a column name and assign a calculation result to the same column.
-
-Example:
-
-<!-- csl: https://help.kusto.windows.net/Samples -->
-```kusto
-print x=1
-| extend x = x + 1, y = x
-| extend x = x + 1
-```
-
-Here's the output:
-
-|x|y|
-|---|---|
-|3|1|
-
-[Scalar expressions](./scalar-data-types/index.md) can include all the usual operators (`+`, `-`, `*`, `/`, `%`), and a range of useful functions are available.
+It is also possible to reuse a column name and assign a calculation result to the same column.
 
 ## Aggregate groups of rows: *summarize*
 
-Count the number of events occur in each state:
+[Aggregation functions](../aggregation-functions.md) enable the goruping and combining of data from multiple rows into a summary value. The summary value depends on the chosen function, for example a count, maximum, or average value.
+
+The [summarize](./summarize-operator.md) operator groups together rows that have the same values in the `by` clause, and then uses a function (for example, `count`) to combine each group in a single row. In this example, the output will show a row for each state, and a column giving the number of storm events per state.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -160,9 +174,7 @@ StormEvents
 | summarize event_count = count() by State
 ```
 
-[summarize](./summarize-operator.md) groups together rows that have the same values in the `by` clause, and then uses an aggregation function (for example, `count`) to combine each group in a single row. In this case, there's a row for each state and a column for the count of rows in that state.
-
-A range of [aggregation functions](aggregation-functions.md) are available. You can use several aggregation functions in one `summarize` operator to produce several computed columns. For example, we could get the count of storms per state, and the sum of unique types of storm per state. Then, we could use [top](./top-operator.md) to get the most storm-affected states:
+A range of [aggregation functions](aggregation-functions.md) is available. You can use several aggregation functions in one [summarize](./summarize-operator.md) operator to produce several computed columns. For example, we could query the number of storms per state, and the number of unique types of storms per state. Then, we could use `top` to get the most storm-affected states:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -171,7 +183,7 @@ StormEvents
 | top 5 by StormCount desc
 ```
 
-Here's the output:
+Output:
 
 |State|StormCount|TypeOfStorms|
 |---|---|---|
@@ -181,15 +193,16 @@ Here's the output:
 |ILLINOIS|2022|23|
 |MISSOURI|2016|20|
 
-In the results of a `summarize` operator:
+In the output table of query containing `summarize`, we see the following:
 
-* Each column is named in `by`.
 * Each computed expression has a column.
 * Each combination of `by` values has a row.
 
-## Summarize by scalar values
+### Summarize by scalar values: *bin*
 
-You can use scalar (numeric, time, or interval) values in the `by` clause, but you'll want to put the values into bins by using the [bin()](./bin-function.md) function:
+To aggregate by numeric, time or interval values, data needs to be grouped into bins using the [bin()](../bin-function.md) function. Using `bin()` gives an understanding of how values are distributed within a certain range and make comparisons between different periods.
+
+The following query counts the number of storms for each day in the week 14-21 February 2007. The function requires a valid [timespan](../scalar-data-types/timespan.md) value, so we use the `1d` query to reduce all the timestamps to intervals of one day.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -198,7 +211,7 @@ StormEvents
 | summarize event_count = count() by bin(StartTime, 1d)
 ```
 
-The query reduces all the timestamps to intervals of one day:
+Output:
 
 |StartTime|event_count|
 |---|---|
@@ -210,13 +223,15 @@ The query reduces all the timestamps to intervals of one day:
 |2007-02-19 00:00:00.0000000|52|
 |2007-02-20 00:00:00.0000000|60|
 
-The [bin()](./bin-function.md) is the same as the floor() function in many languages. It simply reduces every value to the nearest multiple of the modulus that you supply, so that [summarize](./summarize-operator.md) can assign the rows to groups.
+The [bin()](./bin-function.md) operator functions similarly to the floor() function in many programming languages. It rounds every numerical value down to the nearest multiple of the modulus that is stated, so that `summarize` can aggregate the data.
 
 <a name="displaychartortable"></a>
 
-## Display a chart or table: *render*
+## Display a chart: *render*
 
-You can project two columns and use them as the x-axis and the y-axis of a chart:
+Displaying results visually in a chart or graph can help identify patterns, trends, and outliers in your data. This is done using the [render](../render-operator.md) operator.
+
+The following sections of this tutorial will show various examples of how `render` can be used to display results. Let's show the following example in a column chart. Use `project` to select two columns for the x-axis and the y-axis of a chart.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -228,15 +243,17 @@ StormEvents
 | render columnchart
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/event-counts-state.png" alt-text="Screenshot that shows a column chart of storm event counts by state.":::
 
-Although we removed `mid` in the `project` operation, we still need it if we want the chart to display the states in that order.
+Although we removed `mid` in the `project` operation, we still need it if we want the chart to display the states sorted by `mid`.
 
-Strictly speaking, `render` is a feature of the client rather than part of the query language. Still, it's integrated into the language, and it's useful for envisioning your results.
+Strictly speaking, `render` is a feature of the client rather than part of the query language. It is however still integrated into the language as it is useful for graphically displaying results.
 
-## Timecharts
+## Display timecharts
 
-Going back to numeric bins, let's display a time series:
+Another visualisation we can use is a `timechart`, which displays a time series:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -245,11 +262,13 @@ StormEvents
 | render timechart
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/time-series-start-bin.png" alt-text="Screenshot of a line chart of events binned by time.":::
 
-## Multiple series
+## Aggregate multiple series
 
-Use multiple values in a `summarize by` clause to create a separate row for each combination of values:
+Using multiple values in a `summarize by` clause, we can create a separate row for each combination. The following example summarizes the number of occurances per source:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -259,66 +278,112 @@ StormEvents
 | summarize count() by bin(StartTime, 10h), Source
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/table-count-source.png" alt-text="Screenshot that shows a table count by source.":::
 
-Just add the `render` term to the preceding example: `| render timechart`.
+By adding the `render` function to the preceding example (`| render timechart`), we can display this in a timechart:
+
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents 
+| where StartTime > datetime(2007-06-04) and StartTime < datetime(2007-06-10) 
+| where Source in ("Source","Public","Emergency Manager","Trained Spotter","Law Enforcement")
+| summarize count() by bin(StartTime, 10h), Source
+| render timechart
+```
+
+Output:
 
 :::image type="content" source="media/tutorial/line-count-source.png" alt-text="Screenshot that shows a line chart count by source.":::
 
-Notice that `render timechart` uses the first column as the x-axis, and then displays the other columns as separate lines.
+Note that `render timechart` uses the first column as the x-axis, with the data in the second column displayed as separate lines.
 
-## Daily average cycle
+## Plot a distribution
 
-How does activity vary over the average day?
-
-Count events by the time modulo one day, binned into hours.
+Let's see how many storms are there of different durations, and plot it in a timechart.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
 StormEvents
-| extend hour =bin(StartTime % 1d , 1h)
+| extend  duration = EndTime - StartTime
+| where duration > 0s
+| where duration < 3h
+| summarize event_count = count()
+    by bin(duration, 5m)
+| sort by duration asc
+| render timechart
+```
+
+Output:
+
+:::image type="content" source="media/tutorial/event-count-duration.png" alt-text="Screenshot of timechart results for event count by duration.":::
+
+Or, you can use `| render columnchart`:
+
+:::image type="content" source="media/tutorial/column-event-count-duration.png" alt-text="Screenshot of a column chart for event count timechart by duration.":::
+
+## Daily distribution of events
+
+The following example looks at how activity varies over the day. This is done by calculating the number of storm events per hour (counting events by the time modulus of 1 day (`% 1d`), in hourly breakdowns), and then grouping storm events by the hour of the day in the calculated `hour` column. In the rendered timechart, the x-axis represents time (in hours) and the y-axis represents the count of storm events that started during that hour.
+
+<!-- csl: https://help.kusto.windows.net/Samples -->
+```kusto
+StormEvents
+| extend hour =bin(StartTime % 1d, 1d)
 | summarize event_count=count() by hour
 | sort by hour asc
 | render timechart
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/time-count-hour.png" alt-text="Screenshot that shows a timechart count by hour.":::
 
-Currently, `render` doesn't label durations properly, but we could use `| render columnchart` instead:
+We could also use `| render columnchart` as an alternative display:
+
+Output:
 
 :::image type="content" source="media/tutorial/column-count-hour.png" alt-text="Screenshot that shows a column chart count by hour.":::
 
-## Compare multiple daily series
+## Daily distribution of events by state
 
-How does activity vary over the time of day in different states?
+Expanding on the previous example, the following example also shows the distribution of storm activity over time, in different states. 
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
 StormEvents
-| extend hour= bin( StartTime % 1d , 1h)
+| extend hour= bin(StartTime % 1d, 1h)
 | where State in ("GULF OF MEXICO","MAINE","VIRGINIA","WISCONSIN","NORTH DAKOTA","NEW JERSEY","OREGON")
 | summarize event_count=count() by hour, State
+| sort by hour asc
 | render timechart
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/time-hour-state.png" alt-text="Screenshot of a timechart by hour and state.":::
 
-Divide by `1h` to turn the x-axis into an hour number instead of a duration:
+We can also turn the x-axis into a numerical representation of the hour, by dividing by 1h:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
 StormEvents
-| extend hour= bin( StartTime % 1d , 1h)/ 1h
+| extend hour= bin(StartTime % 1d, 1h)/ 1h
 | where State in ("GULF OF MEXICO","MAINE","VIRGINIA","WISCONSIN","NORTH DAKOTA","NEW JERSEY","OREGON")
 | summarize event_count=count() by hour, State
 | render columnchart
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/column-hour-state.png" alt-text="Screenshot that shows a column chart by hour and state.":::
 
-## Join data types
+## Join data types: *join*
 
-How would you find two specific event types and in which state each of them happened?
+Let's look for two specific event types, and in which state each of them happened.
+
+The following example finds states where both lightning events and avalanche events have occurred, and returns a list of distinct states meeting this criteria.
 
 You can pull storm events with the first `EventType` and the second `EventType`, and then join the two sets on `State`:
 
@@ -332,18 +397,17 @@ StormEvents
 ) on State  
 | distinct State
 ```
+Output:
 
 :::image type="content" source="media/tutorial/join-events-lightning-avalanche.png" alt-text="Screenshot that shows joining the events lightning and avalanche.":::
 
 ## User session example of *join*
 
-This section doesn't use the `StormEvents` table.
+This section doesn't use the `StormEvents` table. 
 
-Assume you have data that includes events which mark the start and end of each user session with a unique ID.
+Let's look at a sample table called `Events`. It gives data including events which mark the start and end of user sessions, where each session has a unique ID. 
 
-How would you find out how long each user session lasts?
-
-You can use `extend` to provide an alias for the two timestamps, and then compute the session duration:
+Let's calculate the duration of each user session, using `extend` to provide an alias for the two timestamps.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -359,13 +423,23 @@ Events
 | take 10
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/user-session-extend.png" alt-text="Screenshot of a table of results for user session extend.":::
 
-It's a good practice to use `project` to select just the relevant columns before you perform the join. In the same clause, rename the `timestamp` column.
+It's a good practice to use `project` to select just the relevant columns before you perform the join, and i this case renaming the `timestamp` column in the same clause.
 
-## Plot a distribution
+## Calculate percentiles: *percentile*
 
-Returning to the `StormEvents` table, how many storms are there of different lengths?
+Let's look at the ranges of durations we find in different percentages of storms, using the preceding query from  [Plot a distribution](#plot-a-distribution).
+
+To get this information, use the preceding query from [Plot a distribution](#plot-a-distribution), but replace `render` with:
+
+```kusto
+| summarize percentiles(duration, 5, 20, 50, 80, 95)
+```
+
+The query will look like this:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -376,26 +450,12 @@ StormEvents
 | summarize event_count = count()
     by bin(duration, 5m)
 | sort by duration asc
-| render timechart
-```
-
-:::image type="content" source="media/tutorial/event-count-duration.png" alt-text="Screenshot of timechart results for event count by duration.":::
-
-Or, you can use `| render columnchart`:
-
-:::image type="content" source="media/tutorial/column-event-count-duration.png" alt-text="Screenshot of a column chart for event count timechart by duration.":::
-
-## Percentiles
-
-What ranges of durations do we find in different percentages of storms?
-
-To get this information, use the preceding query from [Plot a distribution](#plot-a-distribution), but replace `render` with:
-
-```kusto
 | summarize percentiles(duration, 5, 20, 50, 80, 95)
 ```
 
-In this case, we didn't use a `by` clause, so the output is a single row:
+Output:
+
+In this case, the output is a single row:
 
 :::image type="content" source="media/tutorial/summarize-percentiles-duration.png" lightbox="media/tutorial/summarize-percentiles-duration.png" alt-text="Screenshot of a table of results for summarize percentiles by duration.":::
 
@@ -405,7 +465,7 @@ We can see from the output that:
 * 50% of storms lasted less than 1 hour and 25 minutes.
 * 95% of storms lasted less than 2 hours and 50 minutes.
 
-To get a separate breakdown for each state, use the `state` column separately with both `summarize` operators:
+To get a breakdown per state, use the `state` column separately with both [summarize](./summarize-operator.md) operators:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -419,11 +479,15 @@ StormEvents
 | summarize percentiles(duration, 5, 20, 50, 80, 95) by State
 ```
 
+Output:
+
 :::image type="content" source="media/tutorial/summarize-percentiles-state.png" alt-text="Table summarize percentiles duration by state.":::
 
-## Percentages
+## Calcuate percentages: *percentage*
 
-Using the StormEvents table, we can calculate the percentage of direct injuries from all injuries.
+Using the `StormEvents` table, we can calculate the number of direct injuries as a percentage of all (total) injuries. 
+
+In summary, this query filters storm events where both direct and indirect injuries are reported (zero count entries are rmeoved). It then calculates the percentage of injuries that are direct, and presents the results against the start time of the storm event.
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -433,7 +497,7 @@ StormEvents
 | project StartTime, InjuriesDirect, InjuriesIndirect, Percentage
 ```
 
-The query removes zero count entries:
+Output:
 
 |StartTime|InjuriesDirect|InjuriesIndirect|Percentage
 |---|---|---|---|
@@ -447,7 +511,7 @@ The query removes zero count entries:
 
 ## Assign a result to a variable: *let*
 
-Use [let](./let-statement.md) to separate out the parts of the query expression in the preceding `join` example. The results are unchanged:
+Use [let](./let-statement.md) to separate out the parts of the query expression in the preceding example in [Join data type](#join-data-type-join). The results are unchanged:
 
 <!-- csl: https://help.kusto.windows.net/Samples -->
 ```kusto
@@ -462,13 +526,49 @@ LightningStorms
 | distinct State
 ```
 
+Output:
+
+{insert output table}
+
 > [!TIP]
-> In Kusto Explorer, to execute the entire query, don't add blank lines between parts of the query.
-> Any two statements must be separated by a semicolon.
+> To execute the entire query, do not add blank lines between parts of the query. Any two statements must be separated by a semicolon.
 
-## Combine data from several databases in a query
+## Combine data from multiple tables: *join*
 
-In the following query, the `Logs` table must be in your default database:
+Joining data from multiple tables within a database allows us to combine information from different sources and create new relationships between data points. The [join](../join-operator.md) operator is used to combine data across tables.
+
+There are two tables in the [Samples database](https://dataexplorer.azure.com/clusters/help/databases/Samples) related to storm events. One is called `StormEvents` and the other is called `PopulationData`. In this section, you'll join the tables to perform data analysis that wouldn't be possible with one table alone.
+
+Both tables contain a `State` column. The `StormEvents` table has many more columns, and the `PopulationData` has only one other column that contains the population of the given state.
+
+We can join the `PopulationData` table with `StormEvents` on the common `State` column, to find the total property damage caused by storms per capita, by state:
+
+```kusto
+StormEvents
+| summarize PropertyDamage = sum(DamageProperty) by State
+| join kind=innerunique PopulationData on State
+| project State, PropertyDamagePerCapita = PropertyDamage / Population
+| sort by PropertyDamagePerCapita
+```
+
+Output:
+
+{insert output table}
+
+Add `| render columnchart` to the query to visualize the result.
+
+{insert output chart}
+
+:::image type="content" source="../media/kql-tutorials/damage-per-capita-chart.png" alt-text="Screenshot of column chart showing property damage per capita by state.":::
+
+> [!TIP]
+> There are many types of joins that you can perform with the `join` operator. See a [list of join flavors](../join-operator.md#returns).
+
+## Combine data from multiple databases: *union*
+
+Combining data from several databases typically involves using the `union` operator, which combines the results of two or more queries into a single result set.
+
+In this example, the `Logs` table must be in your default database:
 
 ```kusto
 Logs | where ...
@@ -480,13 +580,13 @@ To access a table in a different database, use the following syntax:
 database("db").Table
 ```
 
-For example, if you have databases named `Diagnostics` and `Telemetry` and you want to correlate some of the data in the two tables, you might use the following query (assuming `Diagnostics` is your default database):
+For example, let's say you have databases named `Diagnostics` (the query assumes this is the default database) and `Telemetry`, and you want to correlate some of the data in the two tables. Y could do this using the following query:
 
 ```kusto
 Logs | join database("Telemetry").Metrics on Request MachineId | ...
 ```
 
-Use this query if your default database is `Telemetry`:
+If `Telemetry` is your default database, your query would look like this:
 
 ```kusto
 union Requests, database("Diagnostics").Logs | ...
@@ -498,11 +598,10 @@ The preceding two queries assume that both databases are in the cluster you're c
 Logs | join cluster("TelemetryCluster").database("Telemetry").Metrics on Request MachineId | ...
 ```
 
-> [!NOTE]
-> When the cluster is specified, the database is mandatory.
-
 For more information about combining data from several databases in a query, see [cross-database queries](cross-cluster-or-database-queries.md).
 
 ## Related content
 
-* View code samples for the [Kusto Query Language](samples.md?pivots=azuredataexplorer).
+* View the [KQL Quick Reference Guide](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/kql-quick-reference)
+* View [code samples](samples.md?pivots=azuredataexplorer) for the Kusto Query Language.
+


### PR DESCRIPTION
Basic summary of changes:
- Fixing grammatical and spelling errors
- Restructuring the document where beneficial to flow and understanding
- Addition of output tables where necessary, removal of irrelevant info
- Addition of introductory / explanatory text where beneficial

Specific commentary on the proposed changes, and some general comments on the document:

There are inconsistencies in how the output tables are shown - the tutorial begins with embedded tables, and then from the “Timechart” sections onwards, the output tables are embedded as images / screenshots. This needs to be shown consistently throughout the document.

I was unable to test the actual code language, as I do not have access to Azure Data or an MS account for logging in. I did however check the query language to the best of my ability within the document, cross referencing other Kusto resources.

Section: “Select a subset of columns: project” section - I would include the output table for the above query, but I am missing this information.

Section: “Aggregate groups of rows: summarize” - I would add an output table.
 
Section “User session example of join” - I cannot include a link to the referenced table as I don’t have access to that information.
 
When I check my proposed changes the embedded images are not working. The link is written out but the image is not embedded in the document. I cannot figure out how to fix this.  I did try to make adjustments according to Markdown standards, but couldn’t get it exactly right. This is what I tried, by way of example in the “Display a chart: render” section: ![Image](event-counts-state.png "Event counts") 

There are three places where links to other sections within the document are embedded, but I cannot check if the links are working properly: In “Assign a result to a variable: *let*” there is a link back to the section “Join data types” In “Calculate percentiles: *percentile*” there is a link back to the section “Plot a distribution” The list of topics covered in the tutorial, at the beginning of the document.

7. I felt that if there is a section on joining data from different databases (section: “Combine data from several databases in a query”), there should also be a section on joining data from different tables within the same database. I have added a new section “Combine data from multiple tables: join”. I took some of the information I needed from existing Kusto resources. I felt it was a worthwhile additional section to this tutorial, which is quite an extensive one.  I did not have an output table or chart to include but have indicated where they would appear (shown by {...}).

8. Section “Combine data from several databases in a query”: I have proposed changes to this section in my PR, but my overall sense is that this section is beyond the scope of this particular tutorial. I would propose that the only text under this section should be:  “Combining data from several databases typically involves using the `union` operator, which combines the results of two or more queries into a single result set. For more information about combining data from several databases in a query, see cross-database queries {link to the referenced document}.”