### PR TITLE
Update open-telemetry-connector.md (Ingest data from OpenTelemetry to Azure Data Explorer)

### DIFF
--- a/data-explorer/open-telemetry-connector.md
+++ b/data-explorer/open-telemetry-connector.md
@@ -71,11 +71,11 @@ Microsoft Entra application authentication is used for applications that need to
 1. Run the following commands to create tables and schema mapping for the incoming data:
 
     ```kusto
-    .create-merge table <Logs-Table-Name> (Timestamp:datetime, ObservedTimestamp:datetime, TraceId:string, SpanId:string, SeverityText:string, SeverityNumber:int, Body:string, ResourceAttributes:dynamic, LogsAttributes:dynamic) 
+    .create-merge table <Logs-Table-Name> (Timestamp:datetime, ObservedTimestamp:datetime, TraceID:string, SpanID:string, SeverityText:string, SeverityNumber:int, Body:string, ResourceAttributes:dynamic, LogsAttributes:dynamic) 
     
     .create-merge table <Metrics-Table-Name> (Timestamp:datetime, MetricName:string, MetricType:string, MetricUnit:string, MetricDescription:string, MetricValue:real, Host:string, ResourceAttributes:dynamic,MetricAttributes:dynamic) 
     
-    .create-merge table <Traces-Table-Name> (TraceId:string, SpanId:string, ParentId:string, SpanName:string, SpanStatus:string, SpanKind:string, StartTime:datetime, EndTime:datetime, ResourceAttributes:dynamic, TraceAttributes:dynamic, Events:dynamic, Links:dynamic) 
+    .create-merge table <Traces-Table-Name> (TraceID:string, SpanID:string, ParentID:string, SpanName:string, SpanStatus:string, SpanKind:string, StartTime:datetime, EndTime:datetime, ResourceAttributes:dynamic, TraceAttributes:dynamic, Events:dynamic, Links:dynamic) 
     ```
 
 ### Set up streaming ingestion
@@ -110,13 +110,11 @@ In order to ingest your OpenTelemetry data into Azure Data Explorer, you need [d
     | logs_table_name | The target table in the database db_name that stores exported logs data. | OTELLogs
     | traces_table_name | The target table in the database db_name that stores exported traces data. | OTELTraces
     | ingestion_type | Type of ingestion: managed (streaming) or batched | managed
-    | otelmetrics_mapping | Optional parameter. Default table mapping is defined during table creation based on OTeL [metrics attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter#metrics). The default mapping can be changed using this parameter. | &lt;json metrics_table_name mapping>
-    | otellogs_mapping | Optional parameter. Default table mapping is defined during table creation based on OTeL [logs attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter#logs). The default mapping can be changed using this parameter. | &lt;json logs_table_name mapping>
-    | oteltraces_mapping | Optional parameter. Default table mapping is defined during table creation based on OTeL [trace attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter#traces). The default mapping can be changed using this parameter. |&lt;json traces_table_name mapping>
-    | logLevel |  | info
-    | extensions | Services: extension components to enable | [pprof, zpages, health_check]
+    | metrics_table_json_mapping | Optional parameter. Default table mapping is defined during table creation based on OTeL [metrics attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter#metrics). The default mapping can be changed using this parameter. | &lt;json metrics_table_name mapping>
+    | logs_table_json_mapping | Optional parameter. Default table mapping is defined during table creation based on OTeL [logs attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter#logs). The default mapping can be changed using this parameter. | &lt;json logs_table_name mapping>
+    | traces_table_json_mapping | Optional parameter. Default table mapping is defined during table creation based on OTeL [trace attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter#traces). The default mapping can be changed using this parameter. |&lt;json traces_table_name mapping>
     | traces | Services: traces components to enable   |  receivers: [otlp] <br> processors: [batch] <br> exporters: [azuredataexplorer]
-    | metrics | Services: metrics components to enable | receivers: [otlp] <br> processors: [batch] <br> exporters: [logging, azuredataexplorer]
+    | metrics | Services: metrics components to enable | receivers: [otlp] <br> processors: [batch] <br> exporters: [azuredataexplorer]
     | logs | Services: logs components to enable | receivers: [otlp] <br> processors: [batch] <br> exporters: [ azuredataexplorer]
 
 1. Use the "--config" flag to run the Azure Data Explorer exporter.
@@ -124,6 +122,14 @@ In order to ingest your OpenTelemetry data into Azure Data Explorer, you need [d
 The following is an example configuration for the Azure Data Explorer exporter:
 
 ```yaml
+---
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  batch:
 exporters:
   azuredataexplorer:
     cluster_uri: "https://<cluster>.kusto.windows.net"
@@ -135,13 +141,10 @@ exporters:
     logs_table_name: "OTELLogs"
     traces_table_name: "OTELTraces"
     ingestion_type : "managed"
-    otelmetrics_mapping : "<json metrics_table_name mapping>"
-    otellogs_mapping  : "<json logs_table_name mapping>"
-    oteltraces_mapping  : "<json traces_table_name mapping>"
-  logging:
-    logLevel: info
+    metrics_table_json_mapping : "<json metrics_table_name mapping>"
+    logs_table_json_mapping  : "<json logs_table_name mapping>"
+    traces_table_json_mapping  : "<json traces_table_name mapping>"
 service:
-  extensions: [pprof, zpages, health_check]
   pipelines:
     traces:
       receivers: [otlp]
@@ -150,7 +153,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, azuredataexplorer]
+      exporters: [azuredataexplorer]
     logs:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
Proposed changes:
1. Make uppercase 'ID' for column names. It's important as KQL is case sensitive and Kusto uses TraceID, SpanID etc (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go#L39). If left the way it's right now, the fields  TraceId, SpanId and ParentId are empty in Azure Data Explorer.
<img width="484" alt="image" src="https://github.com/MicrosoftDocs/dataexplorer-docs/assets/151688308/345f9eae-46f4-42bd-bdbd-013855a032da">

vs

<img width="484" alt="image" src="https://github.com/MicrosoftDocs/dataexplorer-docs/assets/151688308/329e9ded-f8aa-481a-9ccf-bf6e6e64c0e5">


2. Replace a snippet of yaml configuration with an actual config that includes receiver and processor. 
3. Delete extensions [pprof, zpages, health_check]. They are not relevant to the sample and would cause an error if not defined previously. 
4. Remove logging exporter as not relevant. Log level 'info' would case an error.
5. Update keys for the mapping attributes. The current ones would throw an error: "invalid keys: otellogs_mapping, otelmetrics_mapping, oteltraces_mapping".

Another concern about the document we have, but didn't address here - there is no explanation on how to enable streaming on the cluster level. It says "Streaming must be enabled on Azure Data Explorer cluster to enable the managed option", but no details on how (unlike the tables - for tables there is a command provided). The only way we found was through the Azure portal, but it's only available when the cluster upgraded to Azure Cluster.

