### PR TITLE
Fix incorrect link for sql connection strings

### DIFF
--- a/data-explorer/kusto/api/connection-strings/index.md
+++ b/data-explorer/kusto/api/connection-strings/index.md
@@ -21,7 +21,7 @@ The following table describes the types of connection string formats in Kusto.
 |--|--|
 [Kusto connection strings](kusto.md)|Describe how to communicate with a Kusto service endpoint. Kusto connection strings are modeled after [ADO.NET connection strings](/dotnet/framework/data/adonet/connection-string-syntax).|
 |[Storage connection strings](storage-connection-strings.md)|Describe how to point Kusto at an external storage service such as Azure Blob Storage and Azure Data Lake Storage.|
-|[SQL connection strings](storage-connection-strings.md)|Describe how to point Kusto at an external SQL Server database for query or to [export data to SQL](../../management/data-export/export-data-to-sql.md). These connection strings adhere to the [SqlClient connection strings](/dotnet/framework/data/adonet/connection-string-syntax#sqlclient-connection-strings) specification.|
+|[SQL connection strings](sql-connection-strings.md)|Describe how to point Kusto at an external SQL Server database for query or to [export data to SQL](../../management/data-export/export-data-to-sql.md). These connection strings adhere to the [SqlClient connection strings](/dotnet/framework/data/adonet/connection-string-syntax#sqlclient-connection-strings) specification.|
 
 > [!NOTE]
 > To learn how to specify security principals in connection strings, see [Referencing security principals](../../management/reference-security-principals.md).


### PR DESCRIPTION
SQL connection strings link was to the storage connection strings. Fixing to the right one

