### PR TITLE
docs: clarify `has` is not interchangeable with `contains` 

### DIFF
--- a/data-explorer/kusto/query/datatypes-string-operators.md
+++ b/data-explorer/kusto/query/datatypes-string-operators.md
@@ -27,6 +27,8 @@ Kusto: ad67d136-c1db-4f9f-88ef-d94f3b6b0b5a;KustoExplorerQueryRun
 
 Kusto builds a term index consisting of all terms that are *three characters or more*, and this index is used by string operators such as `has`, `!has`, and so on.  If the query looks for a term that is smaller than three characters, or uses a `contains` operator, then the query will revert to scanning the values in the column. Scanning is much slower than looking up the term in the term index.
 
+While `Explorer` is a substring of `KustoExplorerQueryRun`, `"KustoExplorerQueryRun" has "Explorer"` will return `false` while `"KustoExplorerQueryRun" contains "Explorer"` will return `true`. This is subtle but the behavior is due to the fact that `has` is term-based.
+
 ## Operators on strings
 
 The following abbreviations are used in this article:

--- a/data-explorer/kusto/query/hassuffix-operator.md
+++ b/data-explorer/kusto/query/hassuffix-operator.md
@@ -50,7 +50,7 @@ Rows in *T* for which the predicate is `true`.
 ```kusto
 StormEvents
 | summarize event_count=count() by State
-| where State hassuffix "o"
+| where State hassuffix "th"
 | project State, event_count
 ```
 
@@ -58,10 +58,9 @@ StormEvents
 
 |State|event_count|
 |-----|-----------|
-|COLORADO|1654|
-|OHIO|1233|
-|GULF OF MEXICO|577|
-|NEW MEXICO|527|
-|IDAHO|247|
-|PUERTO RICO|192|
-|LAKE ONTARIO|8|
+|NORTH CAROLINA|1721|
+|SOUTH DAKOTA|1567|
+|SOUTH CAROLINA|915|
+|NORTH DAKOTA|905|
+|ATLANTIC SOUTH|193|
+|ATLANTIC NORTH|188|

--- a/data-explorer/kusto/query/hassuffix-operator.md
+++ b/data-explorer/kusto/query/hassuffix-operator.md
@@ -44,7 +44,7 @@ Rows in *T* for which the predicate is `true`.
 
 :::moniker range="azure-data-explorer"
 > [!div class="nextstepaction"]
-> <a href="https://dataexplorer.azure.com/clusters/help/databases/Samples?query=H4sIAAAAAAAAAwsuyS/KdS1LzSsp5qpRKC7NzU0syqxKVUgFCcUn55fmldiCSQ1NhaRKheCSxJJUoMLyjNSiVAhPISOxuLg0LS2zQkEpXwkoV1CUn5WaXAKR1UE2CQBH0LHRbQAAAA==" target="_blank">Run the query</a>
+> <a href="https://dataexplorer.azure.com/clusters/help/databases/Samples?query=H4sIAAAAAAAAAwsuyS/KdS1LzSsp5qpRKC7NzU0syqxKVUgFCcUn55fmldiCSQ1NhaRKheCSxJJUoMLyjNSiVAhPISOxuLg0LS2zQkGpJEMJKFlQlJ+VmlwCkdZBNgoApSHU8m4AAAA=" target="_blank">Run the query</a>
 ::: moniker-end
 
 ```kusto


### PR DESCRIPTION
I and a number of other Kusto users I've observed authoring queries initially think `contains` and `has` are interchangeable leading to some surprises.

This PR is likely not the best refactoring, but it would be great if the `has` related pages make the behavior more clear in the cases that evaluate to false.
 
`has`'s term based behavior is subtle and while the current docs link to the *[What is a term](https://learn.microsoft.com/en-us/kusto/query/datatypes-string-operators?view=microsoft-fabric#what-is-a-term)* page and show some examples, it's still not obvious to a reader skimming that `"KustoExplorerQueryRun" has "Explorer"` would be `false`.

Because all the tables in the `has*` related pages only show example where results yield to `true` it's hard to glean this fact from those examples (unless you start thinking about double negatives).

Additionally, the query for the `hassuffix` example was changed to better illustrate that the suffix can be on *any* of the terms and not just the last term.

## Make sure you've done the following:

1. **Acrolinx**: Make sure your Acrolinx score is **at least 80** (higher is better) and with **0** spelling issues.
1. **Successful build**: Review the build status to make sure **all files are green** (Succeeded) and there are no errors, warnings, or suggestions.
1. **Preview the pages**: Click each **Preview URL** link, scan the entire page looking for formatting issues, in particular the parts you edited.
1. **Check the Table of Contents**: If you're adding a new markdown file, make sure it is linked from the table of contents.
1. **Sign off**: Once the PR is finalized, add a comment with `#sign-off` . If you need to cancel the sign-off, add a comment with `#hold-off`.

    **NOTE**: *Signing off means the document can be published at any time.*

## Next steps

- All PRs to this repository are reviewed and merged by a human. Automatic merge is disabled on this repository for PRs, even with the qualifies-for-auto-merge label.
- Once all feedback on the PR is addressed, the PR will be merged into the main branch.

[Learn more about how to contribute](https://review.learn.microsoft.com/en-us/help/platform/?branch=main)
