### PR TITLE
Clarify Parquet continuous export performance for wide tables

### DIFF
--- a/data-explorer/kusto/management/data-export/continuous-data-export.md
+++ b/data-explorer/kusto/management/data-export/continuous-data-export.md
@@ -143,7 +143,7 @@ To define continuous export to a delta table, do the following steps:
 * The following formats are allowed on target tables: `CSV`, `TSV`, `JSON`, and `Parquet`.
 * Continuous export isn't designed to work over [materialized views](../materialized-views/materialized-view-overview.md), since a materialized view might be updated, while data exported to storage is always appended and never updated.
 * Continuous export can't be created on [follower databases](/azure/data-explorer/follower) since follower databases are read-only and continuous export requires write operations.
-* Continuous export to Parquet can experience reduced performance for tables with a large number of columns due to per-column encoding overhead.
+* Continuous export to `Parquet` can experience reduced performance for tables with a large number of columns due to per-column encoding overhead.
 * Records in source table must be ingested to the table directly, using an [update policy](../update-policy.md), or [ingest from query commands](../data-ingestion/ingest-from-query.md). If records are moved into the table using [.move extents](../move-extents.md) or using [.rename table](../rename-table-command.md), continuous export might not process these records. See the limitations described in the [Database Cursors](../database-cursor.md#restrictions) page.
 * If the artifacts used by continuous export are intended to trigger Event Grid notifications, see the [known issues section in the Event Grid documentation](/azure/data-explorer/ingest-data-event-grid-overview#known-event-grid-issues).
 

--- a/data-explorer/kusto/management/data-export/continuous-data-export.md
+++ b/data-explorer/kusto/management/data-export/continuous-data-export.md
@@ -143,6 +143,7 @@ To define continuous export to a delta table, do the following steps:
 * The following formats are allowed on target tables: `CSV`, `TSV`, `JSON`, and `Parquet`.
 * Continuous export isn't designed to work over [materialized views](../materialized-views/materialized-view-overview.md), since a materialized view might be updated, while data exported to storage is always appended and never updated.
 * Continuous export can't be created on [follower databases](/azure/data-explorer/follower) since follower databases are read-only and continuous export requires write operations.
+* Continuous export to Parquet can experience reduced performance for tables with a large number of columns due to per-column encoding overhead.
 * Records in source table must be ingested to the table directly, using an [update policy](../update-policy.md), or [ingest from query commands](../data-ingestion/ingest-from-query.md). If records are moved into the table using [.move extents](../move-extents.md) or using [.rename table](../rename-table-command.md), continuous export might not process these records. See the limitations described in the [Database Cursors](../database-cursor.md#restrictions) page.
 * If the artifacts used by continuous export are intended to trigger Event Grid notifications, see the [known issues section in the Event Grid documentation](/azure/data-explorer/ingest-data-event-grid-overview#known-event-grid-issues).
 


### PR DESCRIPTION
Adds a limitation note documenting that continuous export to Parquet can experience reduced performance for tables with a large number of columns due to per-column encoding overhead.
This clarification helps set customer expectations around export performance characteristics for wide tables.